### PR TITLE
🧹 Remove makemigrations from production entrypoint

### DIFF
--- a/backend/entrypoint.prod.sh
+++ b/backend/entrypoint.prod.sh
@@ -21,8 +21,7 @@ while True:
 "
 echo "PostgreSQL started properly."
 
-# generate migrations and migrate
-python manage.py makemigrations
+# migrate
 python manage.py migrate
 
 # collect static files


### PR DESCRIPTION
Removed `python manage.py makemigrations` from `backend/entrypoint.prod.sh`.

This ensures that migrations are pre-generated and committed to version control, following standard best practices for production deployments.

Verification:
- Manually verified the file content to ensure the line is removed.
- Checked syntax of the script using `bash -n`.


---
*PR created automatically by Jules for task [3113689180811687049](https://jules.google.com/task/3113689180811687049) started by @magi-9*