### PR TITLE
test: verify custom JWT claims in login test

### DIFF
--- a/backend/tests/users/test_auth.py
+++ b/backend/tests/users/test_auth.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from rest_framework import status
 import pytest
 from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import AccessToken
 
 User = get_user_model()
 
@@ -22,13 +23,21 @@ def test_use_registration(api_client):
 
 @pytest.mark.django_db
 def test_user_login(api_client, user_factory):
-    user = user_factory(password="password123")
+    user = user_factory(password="password123", is_staff=True, is_superuser=False)
     url = reverse("token_obtain_pair")
     data = {"username": user.username, "password": "password123"}
     response = api_client.post(url, data)
     assert response.status_code == status.HTTP_200_OK
     assert "access" in response.data
     assert "refresh" in response.data
+
+    # Verify custom claims in the access token
+    access_token = response.data["access"]
+    token = AccessToken(access_token)
+
+    assert token["username"] == user.username
+    assert token["is_staff"] == user.is_staff
+    assert token["is_superuser"] == user.is_superuser
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This PR improves the authentication test suite by adding verification for custom JWT claims.

🎯 **What:** The testing gap addressed was the lack of verification for custom claims added to the JWT access token in `CustomTokenObtainPairSerializer`.
📊 **Coverage:** The `test_user_login` scenario now covers the verification of token payload, specifically checking for `username`, `is_staff`, and `is_superuser` claims.
✨ **Result:** Improved reliability of the authentication system by ensuring that important user metadata is correctly encoded in the JWT token.

Note: Local test execution failed due to environment dependency issues (missing `rest_framework` in the available python environments and no internet access to install them). However, the code changes have been manually verified for correctness and reviewed.

---
*PR created automatically by Jules for task [6807113448661779247](https://jules.google.com/task/6807113448661779247) started by @magi-9*