### PR TITLE
🔒 Fix insecure default database password in production

### DIFF
--- a/backend/config/settings/prod.py
+++ b/backend/config/settings/prod.py
@@ -17,9 +17,9 @@ CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS', 'https://localhost
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.environ.get("POSTGRES_DB", "e_plant_db"),
-        "USER": os.environ.get("POSTGRES_USER", "postgres"),
-        "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "password"),
+        "NAME": os.environ["POSTGRES_DB"],
+        "USER": os.environ["POSTGRES_USER"],
+        "PASSWORD": os.environ["POSTGRES_PASSWORD"],
         "HOST": os.environ.get("DB_HOST", "db"),
         "PORT": os.environ.get("DB_PORT", "5432"),
     }


### PR DESCRIPTION
### 🎯 What:
Fixed a security vulnerability where the production database settings had insecure default values.

### ⚠️ Risk:
Previously, if the `POSTGRES_PASSWORD` environment variable was not provided, the application would default to using "password". This could allow unauthorized access to the database if the environment was misconfigured or if an attacker could exploit the default credential.

### 🛡️ Solution:
Removed the default values for `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` in `backend/config/settings/prod.py`. I changed the implementation to use `os.environ["VAR"]`, which forces the application to fail at startup if these variables are not explicitly set in the environment. This ensures a "fail-fast" security posture and prevents accidental deployments with weak or default credentials.

Verified the fix with a script that confirmed `KeyError` is raised when variables are missing and that the configuration is correctly populated when they are present.

---
*PR created automatically by Jules for task [17679248089837365279](https://jules.google.com/task/17679248089837365279) started by @magi-9*