### PR TITLE
Refactor email content to use templates

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -149,3 +149,7 @@ SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=60),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
 }
+
+# Email
+DEFAULT_FROM_EMAIL = "noreply@dentalshop.sk"
+WAREHOUSE_EMAIL = "warehouse@dentalshop.sk"

--- a/backend/orders/serializers.py
+++ b/backend/orders/serializers.py
@@ -6,6 +6,7 @@ import uuid
 from django.db import transaction
 from django.core.mail import send_mail
 from django.conf import settings
+from django.template.loader import render_to_string
 
 
 class OrderItemInputSerializer(serializers.Serializer):
@@ -179,116 +180,23 @@ class OrderCreateSerializer(serializers.ModelSerializer):
 
     def _build_customer_email(self, order):
         """Build customer confirmation email body"""
-        items_text = "\n".join(
-            [
-                f"  - {item.product.name} x {item.quantity} @ {item.price_snapshot}€ = {item.get_subtotal()}€"
-                for item in order.items.all()
-            ]
+        return render_to_string(
+            "orders/email/customer_confirmation.txt", {"order": order}
         )
-
-        payment_info = ""
-        if order.payment_method == "bank_transfer":
-            payment_info = f"""
-PLATOBNÉ ÚDAJE:
-Variabilný symbol: {order.order_number}
-IBAN: SK00 0000 0000 0000 0000 0000
-Suma: {order.total_price}€
-
-Po prijatí platby vám zašleme potvrdenie a objednávku expedujeme.
-"""
-
-        company_info = ""
-        if order.is_company:
-            company_info = f"""
-Fakturačné údaje:
-{order.company_name}
-IČO: {order.ico}
-DIČ: {order.dic}
-"""
-
-        return f"""Dobrý deň {order.customer_name},
-
-Ďakujeme za Vašu objednávku v DentalShop!
-
-ČÍSLO OBJEDNÁVKY: {order.order_number}
-Stav: {order.get_status_display()}
-
-OBJEDNANÉ PRODUKTY:
-{items_text}
-
-CELKOVÁ SUMA: {order.total_price}€
-
-DODACIA ADRESA:
-{order.street}
-{order.city}, {order.postal_code}
-{company_info}
-Telefón: {order.phone}
-Email: {order.email}
-{payment_info}
-Poznámka: {order.notes or "Žiadna"}
-
-V prípade otázok nás neváhajte kontaktovať.
-
-S pozdravom,
-Tím DentalShop
-"""
 
     def _build_warehouse_email(self, order):
         """Build warehouse notification email body"""
-        items_text = "\n".join(
-            [
-                f"  - {item.product.name} (ID: {item.product.id}) x {item.quantity}"
-                for item in order.items.all()
-            ]
+        return render_to_string(
+            "orders/email/warehouse_notification.txt", {"order": order}
         )
-
-        company_info = ""
-        if order.is_company:
-            company_info = f"""
-FIREMNÁ OBJEDNÁVKA:
-{order.company_name}
-IČO: {order.ico}
-DIČ: {order.dic}
-"""
-
-        return f"""NOVÁ OBJEDNÁVKA #{order.order_number}
-
-Zákazník: {order.customer_name}
-Email: {order.email}
-Telefón: {order.phone}
-{company_info}
-Dodacia adresa:
-{order.street}
-{order.city}, {order.postal_code}
-
-PRODUKTY NA VYSKLADNENIE:
-{items_text}
-
-Celková suma: {order.total_price}€
-Platba: {order.get_payment_method_display()}
-Stav: {order.get_status_display()}
-
-Poznámka zákazníka: {order.notes or "Žiadna"}
-"""
 
     def _send_low_stock_emails(self, products):
         """Send notifications about low stock items to warehouse"""
         for product in products:
             subject = f'Upozornenie: Nízky stav zásob pre "{product.name}"'
-            message = f"""Dobrý deň,
-
-Týmto Vás automatický systém upozorňuje na nízky stav zásob produktu:
-
-Produkt: {product.name} (ID: {product.id})
-Aktuálny stav: {product.stock_quantity} ks
-Nastavený limit: {product.low_stock_threshold} ks
-
-Prosím, zvážte včasné doobjednanie tovaru.
-Tento email nebol odoslaný opakovane, kým nedoplníte zásoby nad limit.
-
-S pozdravom,
-Automatický systém DentalShop
-"""
+            message = render_to_string(
+                "orders/email/low_stock_notification.txt", {"product": product}
+            )
             send_mail(
                 subject,
                 message,

--- a/backend/orders/tests.py
+++ b/backend/orders/tests.py
@@ -1,1 +1,75 @@
-# Create your tests here.
+from django.test import TestCase
+from django.core import mail
+from decimal import Decimal
+from products.models import Product
+from orders.serializers import OrderCreateSerializer
+
+
+class EmailContentTest(TestCase):
+    def setUp(self):
+        self.product = Product.objects.create(
+            name="Test Product",
+            price=Decimal("10.00"),
+            stock_quantity=10,
+            low_stock_threshold=5,
+            description="Test Description",
+        )
+        self.order_data = {
+            "customer_name": "John Doe",
+            "email": "john@example.com",
+            "phone": "+1234567890",
+            "street": "123 Main St",
+            "city": "Test City",
+            "postal_code": "12345",
+            "shipping_address": "123 Main St, Test City, 12345",
+            "is_company": False,
+            "payment_method": "bank_transfer",
+            "items": [{"product_id": self.product.id, "quantity": 2}],
+        }
+
+    def test_order_creation_emails(self):
+        serializer = OrderCreateSerializer(data=self.order_data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        order = serializer.save()
+
+        # Check that two emails were sent (customer and warehouse)
+        self.assertEqual(len(mail.outbox), 2)
+
+        customer_email = mail.outbox[0]
+        warehouse_email = mail.outbox[1]
+
+        self.assertEqual(customer_email.to, ["john@example.com"])
+        self.assertIn("Test Product x 2 @ 10.00€ = 20.00€", customer_email.body)
+        self.assertIn("Dobrý deň John Doe,", customer_email.body)
+        self.assertIn("Variabilný symbol: " + order.order_number, customer_email.body)
+
+        self.assertEqual(
+            warehouse_email.to, ["warehouse@dentalshop.sk"]
+        )  # Assuming default setting
+        self.assertIn("NOVÁ OBJEDNÁVKA #" + order.order_number, warehouse_email.body)
+        self.assertIn(
+            "Test Product (ID: " + str(self.product.id) + ") x 2", warehouse_email.body
+        )
+
+    def test_low_stock_email(self):
+        # Update product to trigger low stock
+        self.product.stock_quantity = 6  # Buying 2 will reduce to 4, which is < 5
+        self.product.save()
+
+        serializer = OrderCreateSerializer(data=self.order_data)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        serializer.save()
+
+        # Should send 3 emails: Low stock, Customer, Warehouse
+        self.assertEqual(len(mail.outbox), 3)
+
+        # Check Low Stock Email (sent first)
+        low_stock_email = mail.outbox[0]
+        self.assertIn(
+            'Upozornenie: Nízky stav zásob pre "Test Product"', low_stock_email.subject
+        )
+        self.assertIn(
+            "Produkt: Test Product (ID: " + str(self.product.id) + ")",
+            low_stock_email.body,
+        )
+        self.assertIn("Aktuálny stav: 4 ks", low_stock_email.body)


### PR DESCRIPTION
Moved hardcoded email body construction from `OrderCreateSerializer` to Django templates.
This improves maintainability and separation of concerns.
Templates are located in `backend/orders/templates/orders/email/`.
Added `DEFAULT_FROM_EMAIL` and `WAREHOUSE_EMAIL` to `base.py` to support tests and default configuration.
Consolidated tests into `backend/orders/tests.py` and verified email content fidelity.

---
*PR created automatically by Jules for task [967473901162704190](https://jules.google.com/task/967473901162704190) started by @magi-9*