### PR TITLE
feat: emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,6 @@ WAREHOUSE_EMAIL=warehouse@yourdomain.com
 
 # Vite frontend (optional if needed during build in Dockerfile)
 VITE_API_URL=/api
+
+# Frontend public URL (used in emails, e.g. email verification links)
+FRONTEND_URL=https://yourdomain.com

--- a/backend/tests/users/test_password_reset.py
+++ b/backend/tests/users/test_password_reset.py
@@ -1,0 +1,385 @@
+"""
+Tests for:
+  - POST /auth/password-reset/request/
+  - POST /auth/password-reset/confirm/
+  - POST /auth/resend-verification/
+  - Email rate-limiting (cooldown + block)
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.core import mail
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from rest_framework import status
+
+from users.models import EmailRateLimit
+from users.utils import BLOCK_HOURS, COOLDOWN_SECONDS, MAX_ATTEMPTS, check_and_record_rate_limit
+
+User = get_user_model()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_reset_link(user):
+    """Return (uid, token) for *user*."""
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+    return uid, token
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# password-reset/request/
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+def test_password_reset_request_sends_email(api_client, user_factory):
+    """A valid active user receives a password-reset e-mail."""
+    user = user_factory(email="user@example.com")
+    url = reverse("password_reset_request")
+
+    response = api_client.post(url, {"email": user.email}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(mail.outbox) == 1
+    assert "obnovenie" in mail.outbox[0].subject.lower() or "heslo" in mail.outbox[0].subject.lower()
+    assert user.email in mail.outbox[0].to
+    assert "reset-password" in mail.outbox[0].body
+
+
+@pytest.mark.django_db
+def test_password_reset_request_unknown_email_returns_200(api_client):
+    """Unknown e-mail still returns 200 (no user enumeration)."""
+    url = reverse("password_reset_request")
+    response = api_client.post(url, {"email": "nobody@example.com"}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(mail.outbox) == 0  # nothing was sent
+
+
+@pytest.mark.django_db
+def test_password_reset_request_inactive_user_no_email(api_client, user_factory):
+    """Inactive (unverified) accounts do not receive a reset link."""
+    user = user_factory(is_active=False)
+    url = reverse("password_reset_request")
+    response = api_client.post(url, {"email": user.email}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(mail.outbox) == 0
+
+
+@pytest.mark.django_db
+def test_password_reset_request_missing_email(api_client):
+    """Empty body returns 400."""
+    url = reverse("password_reset_request")
+    response = api_client.post(url, {}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# password-reset/confirm/
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+def test_password_reset_confirm_success(api_client, user_factory):
+    """Valid uid + token + new password → password is changed."""
+    user = user_factory()
+    uid, token = _make_reset_link(user)
+    url = reverse("password_reset_confirm")
+
+    response = api_client.post(
+        url,
+        {"uid": uid, "token": token, "new_password": "newSecure99"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    user.refresh_from_db()
+    assert user.check_password("newSecure99")
+
+
+@pytest.mark.django_db
+def test_password_reset_confirm_invalid_token(api_client, user_factory):
+    """Tampered token is rejected."""
+    user = user_factory()
+    uid, _ = _make_reset_link(user)
+    url = reverse("password_reset_confirm")
+
+    response = api_client.post(
+        url,
+        {"uid": uid, "token": "invalid-token-xyz", "new_password": "newSecure99"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_password_reset_confirm_invalid_uid(api_client):
+    """Garbage uid is rejected."""
+    url = reverse("password_reset_confirm")
+    response = api_client.post(
+        url,
+        {"uid": "notavaliduid", "token": "sometoken", "new_password": "newSecure99"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_password_reset_confirm_token_used_twice(api_client, user_factory):
+    """A token can only be used once — second use is rejected."""
+    user = user_factory()
+    uid, token = _make_reset_link(user)
+    url = reverse("password_reset_confirm")
+    payload = {"uid": uid, "token": token, "new_password": "firstPassword1"}
+
+    first = api_client.post(url, payload, format="json")
+    assert first.status_code == status.HTTP_200_OK
+
+    # Token is now invalid because password_last_changed changed
+    second = api_client.post(
+        url,
+        {"uid": uid, "token": token, "new_password": "secondPassword2"},
+        format="json",
+    )
+    assert second.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_password_reset_confirm_too_short(api_client, user_factory):
+    """Passwords shorter than 8 chars are rejected."""
+    user = user_factory()
+    uid, token = _make_reset_link(user)
+    url = reverse("password_reset_confirm")
+
+    response = api_client.post(
+        url,
+        {"uid": uid, "token": token, "new_password": "short"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    user.refresh_from_db()
+    assert not user.check_password("short")  # password unchanged
+
+
+@pytest.mark.django_db
+def test_password_reset_confirm_missing_fields(api_client):
+    """Missing any required field returns 400."""
+    url = reverse("password_reset_confirm")
+    response = api_client.post(url, {"uid": "abc"}, format="json")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# resend-verification/
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+def test_resend_verification_sends_email(api_client, user_factory):
+    """Inactive user receives a new verification e-mail."""
+    user = user_factory(is_active=False, email="inactive@example.com")
+    url = reverse("resend_verification")
+
+    response = api_client.post(url, {"email": user.email}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(mail.outbox) == 1
+    assert user.email in mail.outbox[0].to
+    assert "verify-email" in mail.outbox[0].body
+
+
+@pytest.mark.django_db
+def test_resend_verification_already_active(api_client, user_factory):
+    """Already-active accounts get a 400 (no point resending)."""
+    user = user_factory(is_active=True)
+    url = reverse("resend_verification")
+
+    response = api_client.post(url, {"email": user.email}, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert len(mail.outbox) == 0
+
+
+@pytest.mark.django_db
+def test_resend_verification_unknown_email(api_client):
+    """Unknown e-mail returns 200 (no user enumeration), nothing sent."""
+    url = reverse("resend_verification")
+    response = api_client.post(url, {"email": "ghost@example.com"}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(mail.outbox) == 0
+
+
+@pytest.mark.django_db
+def test_resend_verification_missing_email(api_client):
+    """Empty body returns 400."""
+    url = reverse("resend_verification")
+    response = api_client.post(url, {}, format="json")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rate limiting – unit tests for check_and_record_rate_limit()
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+def test_rate_limit_first_send_allowed():
+    """First request is always allowed."""
+    result = check_and_record_rate_limit("reset:fresh@example.com")
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_rate_limit_cooldown_blocks_immediate_resend():
+    """A second request within COOLDOWN_SECONDS is rejected."""
+    key = "reset:cooldown@example.com"
+    check_and_record_rate_limit(key)  # first — OK
+
+    result = check_and_record_rate_limit(key)  # second immediately — blocked
+    assert result is not None
+    assert "sekúnd" in result
+
+
+@pytest.mark.django_db
+def test_rate_limit_cooldown_passes_after_wait():
+    """After the cooldown window the send is allowed again."""
+    key = "reset:waitok@example.com"
+    check_and_record_rate_limit(key)
+
+    # Manually back-date last_sent so the cooldown has passed
+    record = EmailRateLimit.objects.get(key=key)
+    record.last_sent = timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1)
+    record.save()
+
+    result = check_and_record_rate_limit(key)
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_rate_limit_blocks_after_max_attempts():
+    """After MAX_ATTEMPTS sends the key is blocked for BLOCK_HOURS."""
+    key = "reset:spammer@example.com"
+
+    for i in range(MAX_ATTEMPTS):
+        # Backdate last_sent so cooldown never fires
+        record, _ = EmailRateLimit.objects.get_or_create(key=key)
+        record.last_sent = timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1)
+        record.save()
+        result = check_and_record_rate_limit(key)
+        if i < MAX_ATTEMPTS - 1:
+            assert result is None, f"Attempt {i + 1} should be allowed"
+        else:
+            # On the MAX_ATTEMPTS-th send the block is applied; the send still
+            # succeeds but the next one will be blocked.
+            assert result is None
+
+    # Next attempt should be blocked
+    result = check_and_record_rate_limit(key)
+    assert result is not None
+    assert "minút" in result or "minútu" in result
+
+
+@pytest.mark.django_db
+def test_rate_limit_block_expires():
+    """After the block duration the key is unblocked and counter resets."""
+    key = "reset:expired@example.com"
+    record = EmailRateLimit.objects.create(
+        key=key,
+        count=0,
+        last_sent=timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1),
+        blocked_until=timezone.now() - timedelta(hours=BLOCK_HOURS + 1),  # already expired
+    )
+    _ = record  # silence lint
+
+    result = check_and_record_rate_limit(key)
+    assert result is None  # block has expired → allowed
+
+
+@pytest.mark.django_db
+def test_rate_limit_active_block_returns_minutes():
+    """An active block returns a human-readable wait message."""
+    key = "reset:blocked@example.com"
+    EmailRateLimit.objects.create(
+        key=key,
+        count=0,
+        last_sent=timezone.now(),
+        blocked_until=timezone.now() + timedelta(hours=BLOCK_HOURS),
+    )
+
+    result = check_and_record_rate_limit(key)
+    assert result is not None
+    assert "minút" in result or "minútu" in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rate limiting – integration tests through the HTTP endpoints
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+def test_password_reset_request_rate_limited_via_api(api_client, user_factory):
+    """Spamming the password-reset endpoint returns 429 after exhausting quota."""
+    user = user_factory()
+    url = reverse("password_reset_request")
+    key = f"reset:{user.email.lower()}"
+
+    for _ in range(MAX_ATTEMPTS):
+        # Bypass cooldown between iterations
+        record, _ = EmailRateLimit.objects.get_or_create(key=key)
+        record.last_sent = timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1)
+        record.save()
+        api_client.post(url, {"email": user.email}, format="json")
+
+    # Next request should be 429
+    record = EmailRateLimit.objects.get(key=key)
+    record.last_sent = timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1)
+    record.save()
+
+    response = api_client.post(url, {"email": user.email}, format="json")
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+@pytest.mark.django_db
+def test_resend_verification_rate_limited_via_api(api_client, user_factory):
+    """Spamming the resend-verification endpoint returns 429 after exhausting quota."""
+    user = user_factory(is_active=False)
+    url = reverse("resend_verification")
+    key = f"verify:{user.email.lower()}"
+
+    for _ in range(MAX_ATTEMPTS):
+        record, _ = EmailRateLimit.objects.get_or_create(key=key)
+        record.last_sent = timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1)
+        record.save()
+        api_client.post(url, {"email": user.email}, format="json")
+
+    record = EmailRateLimit.objects.get(key=key)
+    record.last_sent = timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1)
+    record.save()
+
+    response = api_client.post(url, {"email": user.email}, format="json")
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+@pytest.mark.django_db
+def test_cooldown_between_reset_requests_via_api(api_client, user_factory):
+    """Second password-reset request within 60 s returns 429 with cooldown message."""
+    user = user_factory()
+    url = reverse("password_reset_request")
+
+    first = api_client.post(url, {"email": user.email}, format="json")
+    assert first.status_code == status.HTTP_200_OK
+
+    second = api_client.post(url, {"email": user.email}, format="json")
+    assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert "sekúnd" in second.data.get("error", "")

--- a/backend/tests/users/test_password_reset.py
+++ b/backend/tests/users/test_password_reset.py
@@ -7,10 +7,8 @@ Tests for:
 """
 
 from datetime import timedelta
-from unittest.mock import patch
 
 import pytest
-from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
 from django.urls import reverse
@@ -21,8 +19,6 @@ from rest_framework import status
 
 from users.models import EmailRateLimit
 from users.utils import BLOCK_HOURS, COOLDOWN_SECONDS, MAX_ATTEMPTS, check_and_record_rate_limit
-
-User = get_user_model()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -147,7 +143,8 @@ def test_password_reset_confirm_token_used_twice(api_client, user_factory):
     first = api_client.post(url, payload, format="json")
     assert first.status_code == status.HTTP_200_OK
 
-    # Token is now invalid because password_last_changed changed
+    # Token is now invalid because Django's token generator hashes the password,
+    # so changing the password hash invalidates any previously issued token.
     second = api_client.post(
         url,
         {"uid": uid, "token": token, "new_password": "secondPassword2"},
@@ -202,13 +199,13 @@ def test_resend_verification_sends_email(api_client, user_factory):
 
 @pytest.mark.django_db
 def test_resend_verification_already_active(api_client, user_factory):
-    """Already-active accounts get a 400 (no point resending)."""
+    """Already-active accounts get a generic 200 (no enumeration) and no email is sent."""
     user = user_factory(is_active=True)
     url = reverse("resend_verification")
 
     response = api_client.post(url, {"email": user.email}, format="json")
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_200_OK
     assert len(mail.outbox) == 0
 
 
@@ -332,7 +329,7 @@ def test_password_reset_request_rate_limited_via_api(api_client, user_factory):
     """Spamming the password-reset endpoint returns 429 after exhausting quota."""
     user = user_factory()
     url = reverse("password_reset_request")
-    key = f"reset:{user.email.lower()}"
+    key = f"reset:{user.pk}"
 
     for _ in range(MAX_ATTEMPTS):
         # Bypass cooldown between iterations
@@ -355,7 +352,7 @@ def test_resend_verification_rate_limited_via_api(api_client, user_factory):
     """Spamming the resend-verification endpoint returns 429 after exhausting quota."""
     user = user_factory(is_active=False)
     url = reverse("resend_verification")
-    key = f"verify:{user.email.lower()}"
+    key = f"verify:{user.pk}"
 
     for _ in range(MAX_ATTEMPTS):
         record, _ = EmailRateLimit.objects.get_or_create(key=key)

--- a/backend/tests/users/test_password_reset.py
+++ b/backend/tests/users/test_password_reset.py
@@ -18,12 +18,17 @@ from django.utils.http import urlsafe_base64_encode
 from rest_framework import status
 
 from users.models import EmailRateLimit
-from users.utils import BLOCK_HOURS, COOLDOWN_SECONDS, MAX_ATTEMPTS, check_and_record_rate_limit
-
+from users.utils import (
+    BLOCK_HOURS,
+    COOLDOWN_SECONDS,
+    MAX_ATTEMPTS,
+    check_and_record_rate_limit,
+)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def _make_reset_link(user):
     """Return (uid, token) for *user*."""
@@ -36,6 +41,7 @@ def _make_reset_link(user):
 # password-reset/request/
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @pytest.mark.django_db
 def test_password_reset_request_sends_email(api_client, user_factory):
     """A valid active user receives a password-reset e-mail."""
@@ -46,7 +52,10 @@ def test_password_reset_request_sends_email(api_client, user_factory):
 
     assert response.status_code == status.HTTP_200_OK
     assert len(mail.outbox) == 1
-    assert "obnovenie" in mail.outbox[0].subject.lower() or "heslo" in mail.outbox[0].subject.lower()
+    assert (
+        "obnovenie" in mail.outbox[0].subject.lower()
+        or "heslo" in mail.outbox[0].subject.lower()
+    )
     assert user.email in mail.outbox[0].to
     assert "reset-password" in mail.outbox[0].body
 
@@ -84,6 +93,7 @@ def test_password_reset_request_missing_email(api_client):
 # ─────────────────────────────────────────────────────────────────────────────
 # password-reset/confirm/
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @pytest.mark.django_db
 def test_password_reset_confirm_success(api_client, user_factory):
@@ -183,6 +193,7 @@ def test_password_reset_confirm_missing_fields(api_client):
 # resend-verification/
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @pytest.mark.django_db
 def test_resend_verification_sends_email(api_client, user_factory):
     """Inactive user receives a new verification e-mail."""
@@ -230,6 +241,7 @@ def test_resend_verification_missing_email(api_client):
 # ─────────────────────────────────────────────────────────────────────────────
 # Rate limiting – unit tests for check_and_record_rate_limit()
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 @pytest.mark.django_db
 def test_rate_limit_first_send_allowed():
@@ -296,7 +308,8 @@ def test_rate_limit_block_expires():
         key=key,
         count=0,
         last_sent=timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1),
-        blocked_until=timezone.now() - timedelta(hours=BLOCK_HOURS + 1),  # already expired
+        blocked_until=timezone.now()
+        - timedelta(hours=BLOCK_HOURS + 1),  # already expired
     )
     _ = record  # silence lint
 
@@ -324,12 +337,13 @@ def test_rate_limit_active_block_returns_minutes():
 # Rate limiting – integration tests through the HTTP endpoints
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @pytest.mark.django_db
 def test_password_reset_request_rate_limited_via_api(api_client, user_factory):
     """Spamming the password-reset endpoint returns 429 after exhausting quota."""
     user = user_factory()
     url = reverse("password_reset_request")
-    key = f"reset:{user.pk}"
+    key = f"reset:{user.email.lower()}"
 
     for _ in range(MAX_ATTEMPTS):
         # Bypass cooldown between iterations
@@ -352,7 +366,7 @@ def test_resend_verification_rate_limited_via_api(api_client, user_factory):
     """Spamming the resend-verification endpoint returns 429 after exhausting quota."""
     user = user_factory(is_active=False)
     url = reverse("resend_verification")
-    key = f"verify:{user.pk}"
+    key = f"verify:{user.email.lower()}"
 
     for _ in range(MAX_ATTEMPTS):
         record, _ = EmailRateLimit.objects.get_or_create(key=key)
@@ -365,6 +379,31 @@ def test_resend_verification_rate_limited_via_api(api_client, user_factory):
     record.save()
 
     response = api_client.post(url, {"email": user.email}, format="json")
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+@pytest.mark.django_db
+def test_unknown_email_gets_429_after_quota_exhausted(api_client):
+    """An unknown email address can also exhaust the rate limit and receive 429.
+
+    This ensures both known and unknown emails are treated consistently,
+    preventing account enumeration via differing response codes.
+    """
+    email = "ghost@example.com"
+    url = reverse("password_reset_request")
+    key = f"reset:{email}"
+
+    for _ in range(MAX_ATTEMPTS):
+        record, _ = EmailRateLimit.objects.get_or_create(key=key)
+        record.last_sent = timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1)
+        record.save()
+        api_client.post(url, {"email": email}, format="json")
+
+    record = EmailRateLimit.objects.get(key=key)
+    record.last_sent = timezone.now() - timedelta(seconds=COOLDOWN_SECONDS + 1)
+    record.save()
+
+    response = api_client.post(url, {"email": email}, format="json")
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
 

--- a/backend/users/admin.py
+++ b/backend/users/admin.py
@@ -1,1 +1,25 @@
-# Register your models here.
+from django.contrib import admin
+from .models import CustomUser, GlobalSettings, EmailRateLimit
+
+
+@admin.register(CustomUser)
+class CustomUserAdmin(admin.ModelAdmin):
+    list_display = ("username", "email", "is_active", "is_staff", "date_joined")
+    list_filter = ("is_active", "is_staff")
+    search_fields = ("username", "email")
+
+
+@admin.register(GlobalSettings)
+class GlobalSettingsAdmin(admin.ModelAdmin):
+    pass
+
+
+@admin.register(EmailRateLimit)
+class EmailRateLimitAdmin(admin.ModelAdmin):
+    list_display = ("key", "count", "last_sent", "blocked_until")
+    readonly_fields = ("key", "count", "last_sent", "blocked_until")
+    actions = ["clear_block"]
+
+    @admin.action(description="Clear block / reset counter")
+    def clear_block(self, request, queryset):
+        queryset.update(count=0, blocked_until=None)

--- a/backend/users/admin.py
+++ b/backend/users/admin.py
@@ -22,4 +22,4 @@ class EmailRateLimitAdmin(admin.ModelAdmin):
 
     @admin.action(description="Clear block / reset counter")
     def clear_block(self, request, queryset):
-        queryset.update(count=0, blocked_until=None)
+        queryset.update(count=0, blocked_until=None, last_sent=None)

--- a/backend/users/migrations/0003_emailratelimit.py
+++ b/backend/users/migrations/0003_emailratelimit.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0002_globalsettings_customuser_city_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="EmailRateLimit",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("key", models.CharField(max_length=320, unique=True)),
+                ("count", models.PositiveIntegerField(default=0)),
+                ("last_sent", models.DateTimeField(blank=True, null=True)),
+                ("blocked_until", models.DateTimeField(blank=True, null=True)),
+            ],
+            options={
+                "verbose_name": "Email Rate Limit",
+                "verbose_name_plural": "Email Rate Limits",
+            },
+        ),
+    ]

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
-from django.utils import timezone
 
 
 class EmailRateLimit(models.Model):

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -1,5 +1,22 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.utils import timezone
+
+
+class EmailRateLimit(models.Model):
+    """Tracks per-email rate limits for verification and password-reset sends."""
+
+    key = models.CharField(max_length=320, unique=True)  # e.g. "reset:user@example.com"
+    count = models.PositiveIntegerField(default=0)
+    last_sent = models.DateTimeField(null=True, blank=True)
+    blocked_until = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = "Email Rate Limit"
+        verbose_name_plural = "Email Rate Limits"
+
+    def __str__(self):
+        return self.key
 
 
 class CustomUser(AbstractUser):

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -3,7 +3,10 @@ from django.db import models
 
 
 class EmailRateLimit(models.Model):
-    """Tracks per-email rate limits for verification and password-reset sends."""
+    """
+    Tracks rate limits for email-related actions (e.g. verification, password reset)
+    using an email-derived key (e.g. "reset:user@example.com" or "verify:user@example.com").
+    """
 
     key = models.CharField(max_length=320, unique=True)  # e.g. "reset:user@example.com"
     count = models.PositiveIntegerField(default=0)

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,13 +1,9 @@
 from django.contrib.auth import get_user_model
-from django.utils.http import urlsafe_base64_encode
-from django.utils.encoding import force_bytes
-from django.contrib.auth.tokens import default_token_generator
-from django.core.mail import send_mail
-from django.conf import settings
 from rest_framework import serializers
 import os
 
 from .models import GlobalSettings
+from .utils import send_verification_email
 
 User = get_user_model()
 
@@ -29,33 +25,7 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         user.is_active = False
         user.save()
 
-        # Send Verification Email
-        uid = urlsafe_base64_encode(force_bytes(user.pk))
-        token = default_token_generator.make_token(user)
-
-        frontend_url = os.environ.get("FRONTEND_URL", "http://localhost:5001")
-        verify_url = f"{frontend_url}/verify-email/{uid}/{token}/"
-
-        subject = "Overenie e-mailovej adresy - DentalShop"
-        message = (
-            "Dobrý deň,\n\n"
-            "Ďakujeme za vašu registráciu na DentalShop.\n"
-            "Pre dokončenie registrácie a aktiváciu vášho účtu kliknite na nasledujúci odkaz:\n\n"
-            f"{verify_url}\n\n"
-            "Ak ste si účet nevytvárali, tento e-mail môžete ignorovať.\n\n"
-            "S pozdravom,\nDentalShop Tím"
-        )
-
-        try:
-            send_mail(
-                subject,
-                message,
-                getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@dentalshop.sk"),
-                [user.email],
-                fail_silently=True,
-            )
-        except Exception as e:
-            print(f"Failed to send email: {e}")
+        send_verification_email(user)
 
         return user
 

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
-import os
 
 from .models import GlobalSettings
 from .utils import send_verification_email

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -18,9 +18,21 @@ urlpatterns = [
     path("settings/", GlobalSettingsView.as_view(), name="global_settings"),
     path("register/", RegisterView.as_view(), name="register"),
     path("verify-email/", VerifyEmailView.as_view(), name="verify_email"),
-    path("resend-verification/", ResendVerificationView.as_view(), name="resend_verification"),
-    path("password-reset/request/", PasswordResetRequestView.as_view(), name="password_reset_request"),
-    path("password-reset/confirm/", PasswordResetConfirmView.as_view(), name="password_reset_confirm"),
+    path(
+        "resend-verification/",
+        ResendVerificationView.as_view(),
+        name="resend_verification",
+    ),
+    path(
+        "password-reset/request/",
+        PasswordResetRequestView.as_view(),
+        name="password_reset_request",
+    ),
+    path(
+        "password-reset/confirm/",
+        PasswordResetConfirmView.as_view(),
+        name="password_reset_confirm",
+    ),
     path("me/", MeView.as_view(), name="me"),
     path("admin/users/", AdminUsersListView.as_view(), name="admin_users_list"),
     path(

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -2,6 +2,9 @@ from django.urls import path
 from .views import (
     RegisterView,
     VerifyEmailView,
+    ResendVerificationView,
+    PasswordResetRequestView,
+    PasswordResetConfirmView,
     MeView,
     AdminUsersListView,
     AdminUserCreateView,
@@ -15,6 +18,9 @@ urlpatterns = [
     path("settings/", GlobalSettingsView.as_view(), name="global_settings"),
     path("register/", RegisterView.as_view(), name="register"),
     path("verify-email/", VerifyEmailView.as_view(), name="verify_email"),
+    path("resend-verification/", ResendVerificationView.as_view(), name="resend_verification"),
+    path("password-reset/request/", PasswordResetRequestView.as_view(), name="password_reset_request"),
+    path("password-reset/confirm/", PasswordResetConfirmView.as_view(), name="password_reset_confirm"),
     path("me/", MeView.as_view(), name="me"),
     path("admin/users/", AdminUsersListView.as_view(), name="admin_users_list"),
     path(

--- a/backend/users/utils.py
+++ b/backend/users/utils.py
@@ -1,23 +1,27 @@
 """
 Email rate-limiting helpers and shared email-sending functions.
 
-Rate limit rules (per unique key, e.g. "reset:user@example.com"):
+Rate limit rules (per unique key, e.g. "reset:<user.pk>"):
   - Must wait 60 seconds between sends (cooldown).
   - After 5 sends since the last reset, the key is blocked for 2 hours.
   - Once a block expires the counter resets automatically.
 """
 
+import logging
+import os
 from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.core.mail import send_mail
+from django.db import transaction
 from django.utils import timezone
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
-import os
 
 from .models import EmailRateLimit
+
+logger = logging.getLogger(__name__)
 
 # --------------------------------------------------------------------------- #
 # Configuration
@@ -38,40 +42,46 @@ def check_and_record_rate_limit(key: str) -> str | None:
 
     Returns an error message string if blocked/too-soon, otherwise ``None``
     and records the current send attempt.
+
+    The entire read-modify-write is wrapped in a transaction with
+    select_for_update() to prevent race conditions under concurrent requests.
     """
-    now = timezone.now()
-    record, _ = EmailRateLimit.objects.get_or_create(key=key)
+    with transaction.atomic():
+        # Ensure the row exists, then lock it for this transaction
+        EmailRateLimit.objects.get_or_create(key=key)
+        record = EmailRateLimit.objects.select_for_update().get(key=key)
+        now = timezone.now()
 
-    # Active block?
-    if record.blocked_until and record.blocked_until > now:
-        minutes_left = int((record.blocked_until - now).total_seconds() / 60) + 1
-        return (
-            f"Príliš veľa pokusov. Skúste to znova o {minutes_left} "
-            f"{'minútu' if minutes_left == 1 else 'minút'}."
-        )
+        # Active block?
+        if record.blocked_until and record.blocked_until > now:
+            minutes_left = int((record.blocked_until - now).total_seconds() / 60) + 1
+            return (
+                f"Príliš veľa pokusov. Skúste to znova o {minutes_left} "
+                f"{'minútu' if minutes_left == 1 else 'minút'}."
+            )
 
-    # Expired block → reset counter so the user can start fresh
-    if record.blocked_until and record.blocked_until <= now:
-        record.count = 0
-        record.blocked_until = None
+        # Expired block → reset counter so the user can start fresh
+        if record.blocked_until and record.blocked_until <= now:
+            record.count = 0
+            record.blocked_until = None
 
-    # Cooldown between individual sends
-    if record.last_sent:
-        elapsed = (now - record.last_sent).total_seconds()
-        if elapsed < COOLDOWN_SECONDS:
-            wait = int(COOLDOWN_SECONDS - elapsed) + 1
-            return f"Prosím počkajte {wait} sekúnd pred ďalším odoslaním."
+        # Cooldown between individual sends
+        if record.last_sent:
+            elapsed = (now - record.last_sent).total_seconds()
+            if elapsed < COOLDOWN_SECONDS:
+                wait = int(COOLDOWN_SECONDS - elapsed) + 1
+                return f"Prosím počkajte {wait} sekúnd pred ďalším odoslaním."
 
-    # Record the send
-    record.count += 1
-    record.last_sent = now
+        # Record the send
+        record.count += 1
+        record.last_sent = now
 
-    if record.count >= MAX_ATTEMPTS:
-        record.blocked_until = now + timedelta(hours=BLOCK_HOURS)
-        record.count = 0  # reset for the next window after the block lifts
+        if record.count >= MAX_ATTEMPTS:
+            record.blocked_until = now + timedelta(hours=BLOCK_HOURS)
+            record.count = 0  # reset for the next window after the block lifts
 
-    record.save()
-    return None
+        record.save()
+        return None
 
 
 # --------------------------------------------------------------------------- #
@@ -104,10 +114,10 @@ def send_verification_email(user) -> None:
             message,
             getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@dentalshop.sk"),
             [user.email],
-            fail_silently=True,
+            fail_silently=False,
         )
-    except Exception as exc:
-        print(f"[send_verification_email] Failed: {exc}")
+    except Exception:
+        logger.exception("[send_verification_email] Failed to send to %s", user.email)
 
 
 def send_password_reset_email(user) -> None:
@@ -134,7 +144,7 @@ def send_password_reset_email(user) -> None:
             message,
             getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@dentalshop.sk"),
             [user.email],
-            fail_silently=True,
+            fail_silently=False,
         )
-    except Exception as exc:
-        print(f"[send_password_reset_email] Failed: {exc}")
+    except Exception:
+        logger.exception("[send_password_reset_email] Failed to send to %s", user.email)

--- a/backend/users/utils.py
+++ b/backend/users/utils.py
@@ -1,10 +1,12 @@
 """
 Email rate-limiting helpers and shared email-sending functions.
 
-Rate limit rules (per unique key, e.g. "reset:<user.pk>"):
+Rate limit rules (per email-derived key, e.g. "reset:user@example.com"):
   - Must wait 60 seconds between sends (cooldown).
   - After 5 sends since the last reset, the key is blocked for 2 hours.
   - Once a block expires the counter resets automatically.
+  - Rate-limiting is applied before the user lookup so that unknown
+    and known email addresses receive consistent responses (no enumeration).
 """
 
 import logging
@@ -27,14 +29,15 @@ logger = logging.getLogger(__name__)
 # Configuration
 # --------------------------------------------------------------------------- #
 
-COOLDOWN_SECONDS = 60          # minimum gap between consecutive sends
-MAX_ATTEMPTS = 5               # sends before triggering a block
-BLOCK_HOURS = 2                # how long the block lasts
+COOLDOWN_SECONDS = 60  # minimum gap between consecutive sends
+MAX_ATTEMPTS = 5  # sends before triggering a block
+BLOCK_HOURS = 2  # how long the block lasts
 
 
 # --------------------------------------------------------------------------- #
 # Rate limiting
 # --------------------------------------------------------------------------- #
+
 
 def check_and_record_rate_limit(key: str) -> str | None:
     """
@@ -88,8 +91,9 @@ def check_and_record_rate_limit(key: str) -> str | None:
 # Email helpers
 # --------------------------------------------------------------------------- #
 
+
 def _frontend_url() -> str:
-    return os.environ.get("FRONTEND_URL", "http://localhost:5001")
+    return os.environ.get("FRONTEND_URL", "http://localhost:5001").rstrip("/")
 
 
 def send_verification_email(user) -> None:

--- a/backend/users/utils.py
+++ b/backend/users/utils.py
@@ -1,0 +1,140 @@
+"""
+Email rate-limiting helpers and shared email-sending functions.
+
+Rate limit rules (per unique key, e.g. "reset:user@example.com"):
+  - Must wait 60 seconds between sends (cooldown).
+  - After 5 sends since the last reset, the key is blocked for 2 hours.
+  - Once a block expires the counter resets automatically.
+"""
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.contrib.auth.tokens import default_token_generator
+from django.core.mail import send_mail
+from django.utils import timezone
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+import os
+
+from .models import EmailRateLimit
+
+# --------------------------------------------------------------------------- #
+# Configuration
+# --------------------------------------------------------------------------- #
+
+COOLDOWN_SECONDS = 60          # minimum gap between consecutive sends
+MAX_ATTEMPTS = 5               # sends before triggering a block
+BLOCK_HOURS = 2                # how long the block lasts
+
+
+# --------------------------------------------------------------------------- #
+# Rate limiting
+# --------------------------------------------------------------------------- #
+
+def check_and_record_rate_limit(key: str) -> str | None:
+    """
+    Check whether *key* is rate-limited.
+
+    Returns an error message string if blocked/too-soon, otherwise ``None``
+    and records the current send attempt.
+    """
+    now = timezone.now()
+    record, _ = EmailRateLimit.objects.get_or_create(key=key)
+
+    # Active block?
+    if record.blocked_until and record.blocked_until > now:
+        minutes_left = int((record.blocked_until - now).total_seconds() / 60) + 1
+        return (
+            f"Príliš veľa pokusov. Skúste to znova o {minutes_left} "
+            f"{'minútu' if minutes_left == 1 else 'minút'}."
+        )
+
+    # Expired block → reset counter so the user can start fresh
+    if record.blocked_until and record.blocked_until <= now:
+        record.count = 0
+        record.blocked_until = None
+
+    # Cooldown between individual sends
+    if record.last_sent:
+        elapsed = (now - record.last_sent).total_seconds()
+        if elapsed < COOLDOWN_SECONDS:
+            wait = int(COOLDOWN_SECONDS - elapsed) + 1
+            return f"Prosím počkajte {wait} sekúnd pred ďalším odoslaním."
+
+    # Record the send
+    record.count += 1
+    record.last_sent = now
+
+    if record.count >= MAX_ATTEMPTS:
+        record.blocked_until = now + timedelta(hours=BLOCK_HOURS)
+        record.count = 0  # reset for the next window after the block lifts
+
+    record.save()
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Email helpers
+# --------------------------------------------------------------------------- #
+
+def _frontend_url() -> str:
+    return os.environ.get("FRONTEND_URL", "http://localhost:5001")
+
+
+def send_verification_email(user) -> None:
+    """Send (or resend) the e-mail verification link to *user*."""
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+    verify_url = f"{_frontend_url()}/verify-email/{uid}/{token}/"
+
+    subject = "Overenie e-mailovej adresy - DentalShop"
+    message = (
+        "Dobrý deň,\n\n"
+        "Ďakujeme za vašu registráciu na DentalShop.\n"
+        "Pre dokončenie registrácie a aktiváciu vášho účtu kliknite na nasledujúci odkaz:\n\n"
+        f"{verify_url}\n\n"
+        "Ak ste si účet nevytvárali, tento e-mail môžete ignorovať.\n\n"
+        "S pozdravom,\nDentalShop Tím"
+    )
+
+    try:
+        send_mail(
+            subject,
+            message,
+            getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@dentalshop.sk"),
+            [user.email],
+            fail_silently=True,
+        )
+    except Exception as exc:
+        print(f"[send_verification_email] Failed: {exc}")
+
+
+def send_password_reset_email(user) -> None:
+    """Send a password-reset link to *user*."""
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+    reset_url = f"{_frontend_url()}/reset-password/{uid}/{token}/"
+
+    subject = "Obnovenie hesla - DentalShop"
+    message = (
+        "Dobrý deň,\n\n"
+        "Dostali sme žiadosť o obnovenie hesla pre váš účet na DentalShop.\n"
+        "Pre nastavenie nového hesla kliknite na nasledujúci odkaz:\n\n"
+        f"{reset_url}\n\n"
+        "Odkaz je platný 3 dni.\n\n"
+        "Ak ste o obnovenie hesla nežiadali, tento e-mail môžete ignorovať — "
+        "vaše heslo zostane nezmenené.\n\n"
+        "S pozdravom,\nDentalShop Tím"
+    )
+
+    try:
+        send_mail(
+            subject,
+            message,
+            getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@dentalshop.sk"),
+            [user.email],
+            fail_silently=True,
+        )
+    except Exception as exc:
+        print(f"[send_password_reset_email] Failed: {exc}")

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -15,6 +15,7 @@ from .serializers import (
     AdminUserUpdateSerializer,
 )
 from .models import GlobalSettings
+from .utils import check_and_record_rate_limit, send_verification_email, send_password_reset_email
 
 User = get_user_model()
 
@@ -53,6 +54,99 @@ class VerifyEmailView(views.APIView):
         else:
             return Response(
                 {"error": "Overovací odkaz je neplatný alebo už expiroval."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+
+class ResendVerificationView(views.APIView):
+    permission_classes = (permissions.AllowAny,)
+
+    def post(self, request):
+        email = request.data.get("email", "").strip().lower()
+        if not email:
+            return Response(
+                {"error": "Zadajte e-mailovú adresu."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        rate_error = check_and_record_rate_limit(f"verify:{email}")
+        if rate_error:
+            return Response({"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
+        try:
+            user = User.objects.get(email__iexact=email)
+        except User.DoesNotExist:
+            # Don't leak whether the email exists
+            return Response({"detail": "Ak účet existuje a nebol overený, odoslali sme nový odkaz."})
+
+        if user.is_active:
+            return Response(
+                {"error": "Tento účet je už overený. Môžete sa prihlásiť."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        send_verification_email(user)
+        return Response({"detail": "Ak účet existuje a nebol overený, odoslali sme nový odkaz."})
+
+
+class PasswordResetRequestView(views.APIView):
+    permission_classes = (permissions.AllowAny,)
+
+    def post(self, request):
+        email = request.data.get("email", "").strip().lower()
+        if not email:
+            return Response(
+                {"error": "Zadajte e-mailovú adresu."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        rate_error = check_and_record_rate_limit(f"reset:{email}")
+        if rate_error:
+            return Response({"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
+        try:
+            user = User.objects.get(email__iexact=email)
+            if user.is_active:
+                send_password_reset_email(user)
+        except User.DoesNotExist:
+            pass  # Don't leak whether the email exists
+
+        return Response({"detail": "Ak účet s touto adresou existuje, odoslali sme odkaz na obnovenie hesla."})
+
+
+class PasswordResetConfirmView(views.APIView):
+    permission_classes = (permissions.AllowAny,)
+
+    def post(self, request):
+        uidb64 = request.data.get("uid")
+        token = request.data.get("token")
+        new_password = request.data.get("new_password", "")
+
+        if not uidb64 or not token or not new_password:
+            return Response(
+                {"error": "Chýbajúce údaje."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if len(new_password) < 8:
+            return Response(
+                {"error": "Heslo musí mať aspoň 8 znakov."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            uid = force_str(urlsafe_base64_decode(uidb64))
+            user = User.objects.get(pk=uid)
+        except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+            user = None
+
+        if user is not None and default_token_generator.check_token(user, token):
+            user.set_password(new_password)
+            user.save()
+            return Response({"success": "Heslo bolo úspešne zmenené. Teraz sa môžete prihlásiť."})
+        else:
+            return Response(
+                {"error": "Odkaz na obnovenie hesla je neplatný alebo expiroval."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -15,7 +15,11 @@ from .serializers import (
     AdminUserUpdateSerializer,
 )
 from .models import GlobalSettings
-from .utils import check_and_record_rate_limit, send_verification_email, send_password_reset_email
+from .utils import (
+    check_and_record_rate_limit,
+    send_verification_email,
+    send_password_reset_email,
+)
 
 User = get_user_model()
 
@@ -69,16 +73,22 @@ class ResendVerificationView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        generic_response = Response({"detail": "Ak účet existuje a nebol overený, odoslali sme nový odkaz."})
+        # Rate-limit by email before user lookup so all addresses
+        # get consistent 429 responses (prevents account enumeration).
+        rate_error = check_and_record_rate_limit(f"verify:{email}")
+        if rate_error:
+            return Response(
+                {"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS
+            )
+
+        generic_response = Response(
+            {"detail": "Ak účet existuje a nebol overený, odoslali sme nový odkaz."}
+        )
 
         try:
             user = User.objects.get(email__iexact=email)
         except User.DoesNotExist:
             return generic_response  # Don't leak whether the email exists
-
-        rate_error = check_and_record_rate_limit(f"verify:{user.pk}")
-        if rate_error:
-            return Response({"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS)
 
         if not user.is_active:
             send_verification_email(user)
@@ -97,18 +107,24 @@ class PasswordResetRequestView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # Rate-limit by email before user lookup so all addresses
+        # get consistent 429 responses (prevents account enumeration).
+        rate_error = check_and_record_rate_limit(f"reset:{email}")
+        if rate_error:
+            return Response(
+                {"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS
+            )
+
         generic_response = Response(
-            {"detail": "Ak účet s touto adresou existuje, odoslali sme odkaz na obnovenie hesla."}
+            {
+                "detail": "Ak účet s touto adresou existuje, odoslali sme odkaz na obnovenie hesla."
+            }
         )
 
         try:
             user = User.objects.get(email__iexact=email)
         except User.DoesNotExist:
             return generic_response  # Don't leak whether the email exists
-
-        rate_error = check_and_record_rate_limit(f"reset:{user.pk}")
-        if rate_error:
-            return Response({"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS)
 
         if user.is_active:
             send_password_reset_email(user)
@@ -145,7 +161,9 @@ class PasswordResetConfirmView(views.APIView):
         if user is not None and default_token_generator.check_token(user, token):
             user.set_password(new_password)
             user.save()
-            return Response({"success": "Heslo bolo úspešne zmenené. Teraz sa môžete prihlásiť."})
+            return Response(
+                {"success": "Heslo bolo úspešne zmenené. Teraz sa môžete prihlásiť."}
+            )
         else:
             return Response(
                 {"error": "Odkaz na obnovenie hesla je neplatný alebo expiroval."},

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -69,24 +69,21 @@ class ResendVerificationView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        rate_error = check_and_record_rate_limit(f"verify:{email}")
-        if rate_error:
-            return Response({"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+        generic_response = Response({"detail": "Ak účet existuje a nebol overený, odoslali sme nový odkaz."})
 
         try:
             user = User.objects.get(email__iexact=email)
         except User.DoesNotExist:
-            # Don't leak whether the email exists
-            return Response({"detail": "Ak účet existuje a nebol overený, odoslali sme nový odkaz."})
+            return generic_response  # Don't leak whether the email exists
 
-        if user.is_active:
-            return Response(
-                {"error": "Tento účet je už overený. Môžete sa prihlásiť."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        rate_error = check_and_record_rate_limit(f"verify:{user.pk}")
+        if rate_error:
+            return Response({"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS)
 
-        send_verification_email(user)
-        return Response({"detail": "Ak účet existuje a nebol overený, odoslali sme nový odkaz."})
+        if not user.is_active:
+            send_verification_email(user)
+
+        return generic_response
 
 
 class PasswordResetRequestView(views.APIView):
@@ -100,18 +97,23 @@ class PasswordResetRequestView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        rate_error = check_and_record_rate_limit(f"reset:{email}")
-        if rate_error:
-            return Response({"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+        generic_response = Response(
+            {"detail": "Ak účet s touto adresou existuje, odoslali sme odkaz na obnovenie hesla."}
+        )
 
         try:
             user = User.objects.get(email__iexact=email)
-            if user.is_active:
-                send_password_reset_email(user)
         except User.DoesNotExist:
-            pass  # Don't leak whether the email exists
+            return generic_response  # Don't leak whether the email exists
 
-        return Response({"detail": "Ak účet s touto adresou existuje, odoslali sme odkaz na obnovenie hesla."})
+        rate_error = check_and_record_rate_limit(f"reset:{user.pk}")
+        if rate_error:
+            return Response({"error": rate_error}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
+        if user.is_active:
+            send_password_reset_email(user)
+
+        return generic_response
 
 
 class PasswordResetConfirmView(views.APIView):

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌿</text></svg>" />
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%8C%BF%3C/text%3E%3C/svg%3E" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>E-Plant</title>
   </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🌿</text></svg>" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>E-Plant</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ import PrivacyPage from './pages/PrivacyPage';
 import ComplaintsPage from './pages/ComplaintsPage';
 import WithdrawalPage from './pages/WithdrawalPage';
 import VerifyEmailPage from './pages/VerifyEmailPage';
+import ForgotPasswordPage from './pages/ForgotPasswordPage';
+import ResetPasswordPage from './pages/ResetPasswordPage';
 
 import { Toaster } from 'react-hot-toast';
 import { Link } from 'react-router-dom';
@@ -43,6 +45,8 @@ function App() {
               <Route path="/admin/products" element={<AdminProducts />} />
               <Route path="/admin/users" element={<AdminUsers />} />
               <Route path="/verify-email/:uid/:token" element={<VerifyEmailPage />} />
+              <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+              <Route path="/reset-password/:uid/:token" element={<ResetPasswordPage />} />
               <Route path="/admin/orders" element={<AdminOrders />} />
               <Route path="/admin/settings" element={<AdminSettings />} />
               <Route path="/terms" element={<TermsPage />} />

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -26,6 +26,21 @@ export const verifyEmail = async (uid: string, token: string) => {
     return response.data;
 };
 
+export const resendVerification = async (email: string) => {
+    const response = await client.post('/auth/resend-verification/', { email });
+    return response.data;
+};
+
+export const requestPasswordReset = async (email: string) => {
+    const response = await client.post('/auth/password-reset/request/', { email });
+    return response.data;
+};
+
+export const confirmPasswordReset = async (uid: string, token: string, new_password: string) => {
+    const response = await client.post('/auth/password-reset/confirm/', { uid, token, new_password });
+    return response.data;
+};
+
 export const getMe = async () => {
     const response = await client.get('/auth/me/');
     return response.data;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -36,8 +36,8 @@ export const requestPasswordReset = async (email: string) => {
     return response.data;
 };
 
-export const confirmPasswordReset = async (uid: string, token: string, new_password: string) => {
-    const response = await client.post('/auth/password-reset/confirm/', { uid, token, new_password });
+export const confirmPasswordReset = async (uid: string, token: string, newPassword: string) => {
+    const response = await client.post('/auth/password-reset/confirm/', { uid, token, new_password: newPassword });
     return response.data;
 };
 

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { Link } from 'react-router-dom';
+import { EnvelopeIcon } from '@heroicons/react/24/outline';
+import { requestPasswordReset } from '../api/auth';
+
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState('');
+    const [errorMsg, setErrorMsg] = useState('');
+    const [submitted, setSubmitted] = useState(false);
+
+    const mutation = useMutation({
+        mutationFn: () => requestPasswordReset(email),
+        onSuccess: () => {
+            setSubmitted(true);
+        },
+        onError: (error: unknown) => {
+            if (isAxiosError(error)) {
+                if (error.response?.status === 429) {
+                    setErrorMsg(error.response.data?.error || 'Príliš veľa pokusov. Skúste neskôr.');
+                } else {
+                    setErrorMsg(error.response?.data?.error || 'Nastala chyba. Skúste to znova.');
+                }
+            } else {
+                setErrorMsg('Nastala chyba. Skúste to znova.');
+            }
+        },
+    });
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setErrorMsg('');
+        mutation.mutate();
+    };
+
+    return (
+        <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 flex-grow">
+            <div className="max-w-md w-full space-y-8 bg-white p-10 rounded-xl shadow-lg">
+                <div>
+                    <div className="mx-auto h-12 w-12 bg-blue-100 rounded-full flex items-center justify-center">
+                        <EnvelopeIcon className="h-6 w-6 text-blue-600" />
+                    </div>
+                    <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+                        Zabudnuté heslo
+                    </h2>
+                    <p className="mt-2 text-center text-sm text-gray-600">
+                        Zadajte vašu e-mailovú adresu a my vám pošleme odkaz na obnovenie hesla.
+                    </p>
+                </div>
+
+                {submitted ? (
+                    <div className="rounded-md bg-green-50 p-6 text-center">
+                        <p className="text-sm font-medium text-green-800">
+                            Ak účet s touto adresou existuje, odoslali sme odkaz na obnovenie hesla.
+                        </p>
+                        <p className="mt-2 text-xs text-green-700">
+                            Skontrolujte si priečinok so spamom, ak e-mail nevidíte do pár minút.
+                        </p>
+                        <Link
+                            to="/login"
+                            className="mt-4 inline-block font-medium text-blue-600 hover:text-blue-500 text-sm"
+                        >
+                            Späť na prihlásenie
+                        </Link>
+                    </div>
+                ) : (
+                    <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+                        {errorMsg && (
+                            <div className="rounded-md bg-red-50 p-4">
+                                <p className="text-sm font-medium text-red-800">{errorMsg}</p>
+                            </div>
+                        )}
+
+                        <div>
+                            <label htmlFor="email" className="sr-only">E-mailová adresa</label>
+                            <input
+                                id="email"
+                                name="email"
+                                type="email"
+                                required
+                                className="appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                placeholder="E-mailová adresa"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                            />
+                        </div>
+
+                        <div>
+                            <button
+                                type="submit"
+                                disabled={mutation.isPending}
+                                className="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 disabled:opacity-50"
+                            >
+                                {mutation.isPending ? 'Odosielam...' : 'Odoslať odkaz na obnovenie'}
+                            </button>
+                        </div>
+
+                        <div className="text-center">
+                            <Link to="/login" className="text-sm font-medium text-blue-600 hover:text-blue-500">
+                                Späť na prihlásenie
+                            </Link>
+                        </div>
+                    </form>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -99,9 +99,9 @@ export default function LoginPage() {
                         </div>
 
                         <div className="text-sm">
-                            <button type="button" className="font-medium text-blue-600 hover:text-blue-500">
+                            <Link to="/forgot-password" className="font-medium text-blue-600 hover:text-blue-500">
                                 Zabudli ste heslo?
-                            </button>
+                            </Link>
                         </div>
                     </div>
 

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { useParams, Link } from 'react-router-dom';
+import { LockClosedIcon, CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { confirmPasswordReset } from '../api/auth';
+
+export default function ResetPasswordPage() {
+    const { uid, token } = useParams();
+    const [newPassword, setNewPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [errorMsg, setErrorMsg] = useState('');
+    const [success, setSuccess] = useState(false);
+
+    const mutation = useMutation({
+        mutationFn: () => confirmPasswordReset(uid!, token!, newPassword),
+        onSuccess: () => {
+            setSuccess(true);
+        },
+        onError: (error: unknown) => {
+            if (isAxiosError(error)) {
+                setErrorMsg(error.response?.data?.error || 'Nastala chyba. Skúste to znova.');
+            } else {
+                setErrorMsg('Nastala chyba. Skúste to znova.');
+            }
+        },
+    });
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setErrorMsg('');
+
+        if (!uid || !token) {
+            setErrorMsg('Neplatný odkaz. Chýbajú parametre.');
+            return;
+        }
+        if (newPassword.length < 8) {
+            setErrorMsg('Heslo musí mať aspoň 8 znakov.');
+            return;
+        }
+        if (newPassword !== confirmPassword) {
+            setErrorMsg('Heslá sa nezhodujú.');
+            return;
+        }
+
+        mutation.mutate();
+    };
+
+    if (!uid || !token) {
+        return (
+            <div className="min-h-full flex items-center justify-center py-12 px-4 bg-gray-50 flex-grow">
+                <div className="max-w-md w-full bg-white p-10 rounded-xl shadow-lg text-center">
+                    <XCircleIcon className="h-16 w-16 text-red-500 mx-auto" />
+                    <h3 className="mt-4 text-lg font-medium text-gray-900">Neplatný odkaz</h3>
+                    <p className="mt-2 text-sm text-gray-600">Chýbajú parametre odkazu na obnovenie hesla.</p>
+                    <Link to="/forgot-password" className="mt-4 inline-block text-sm font-medium text-blue-600 hover:text-blue-500">
+                        Požiadať o nový odkaz
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 flex-grow">
+            <div className="max-w-md w-full space-y-8 bg-white p-10 rounded-xl shadow-lg">
+                <div>
+                    <div className="mx-auto h-12 w-12 bg-blue-100 rounded-full flex items-center justify-center">
+                        <LockClosedIcon className="h-6 w-6 text-blue-600" />
+                    </div>
+                    <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+                        Nastavenie nového hesla
+                    </h2>
+                </div>
+
+                {success ? (
+                    <div className="text-center">
+                        <CheckCircleIcon className="h-16 w-16 text-green-500 mx-auto" />
+                        <h3 className="mt-4 text-lg font-medium text-gray-900">Heslo bolo zmenené</h3>
+                        <p className="mt-2 text-sm text-gray-600">Teraz sa môžete prihlásiť s novým heslom.</p>
+                        <Link
+                            to="/login"
+                            className="mt-6 inline-flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+                        >
+                            Prihlásiť sa
+                        </Link>
+                    </div>
+                ) : (
+                    <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+                        {errorMsg && (
+                            <div className="rounded-md bg-red-50 p-4">
+                                <p className="text-sm font-medium text-red-800">{errorMsg}</p>
+                            </div>
+                        )}
+
+                        <div className="space-y-4">
+                            <div>
+                                <label htmlFor="new_password" className="block text-sm font-medium text-gray-700">
+                                    Nové heslo
+                                </label>
+                                <input
+                                    id="new_password"
+                                    name="new_password"
+                                    type="password"
+                                    required
+                                    minLength={8}
+                                    className="mt-1 appearance-none block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                    placeholder="Minimálne 8 znakov"
+                                    value={newPassword}
+                                    onChange={(e) => setNewPassword(e.target.value)}
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="confirm_password" className="block text-sm font-medium text-gray-700">
+                                    Potvrďte nové heslo
+                                </label>
+                                <input
+                                    id="confirm_password"
+                                    name="confirm_password"
+                                    type="password"
+                                    required
+                                    className="mt-1 appearance-none block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                                    placeholder="Zopakujte heslo"
+                                    value={confirmPassword}
+                                    onChange={(e) => setConfirmPassword(e.target.value)}
+                                />
+                            </div>
+                        </div>
+
+                        <div>
+                            <button
+                                type="submit"
+                                disabled={mutation.isPending}
+                                className="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 disabled:opacity-50"
+                            >
+                                {mutation.isPending ? 'Ukladám...' : 'Nastaviť nové heslo'}
+                            </button>
+                        </div>
+                    </form>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Added backend endpoints for resend verification and password reset (request/confirm) with per-key rate limiting backed by a new EmailRateLimit model.
Added frontend “Forgot password” and “Reset password” pages and wired routes/links to them.
Updated app branding bits (title + favicon).