### PR TITLE
feat: improvements

### DIFF
--- a/backend/.flake8
+++ b/backend/.flake8
@@ -2,3 +2,6 @@
 max-line-length = 120
 extend-ignore = E203
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,migrations
+per-file-ignores =
+    orders/serializers.py:E501
+    users/utils.py:E501

--- a/backend/orders/serializers.py
+++ b/backend/orders/serializers.py
@@ -302,7 +302,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 f'<td style="padding:10px 12px;font-size:14px;color:#475569;text-align:center;border-bottom:1px solid #f1f5f9;">{item.quantity}</td>'
                 f'<td style="padding:10px 12px;font-size:14px;color:#475569;text-align:right;border-bottom:1px solid #f1f5f9;">{item.price_snapshot}&nbsp;&euro;</td>'
                 f'<td style="padding:10px 12px;font-size:14px;font-weight:600;color:#1e293b;text-align:right;border-bottom:1px solid #f1f5f9;">{item.get_subtotal()}&nbsp;&euro;</td>'
-                '</tr>'
+                "</tr>"
             )
 
         payment_block = ""
@@ -310,7 +310,8 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
             iban_row = (
                 f'<tr><td style="padding:4px 16px;font-size:13px;color:#64748b;">IBAN:</td>'
                 f'<td style="padding:4px 16px 4px 8px;font-size:13px;font-weight:600;color:#1e293b;">{shop.iban}</td></tr>'
-                if shop.iban else ""
+                if shop.iban
+                else ""
             )
             payment_block = (
                 '<table width="100%" cellpadding="0" cellspacing="0"'
@@ -319,10 +320,10 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 'text-transform:uppercase;letter-spacing:0.8px;">Platobné údaje</td></tr>'
                 f'<tr><td style="padding:4px 16px;font-size:13px;color:#64748b;">Variabilný symbol:</td>'
                 f'<td style="padding:4px 16px 4px 8px;font-size:13px;font-weight:700;color:#1e40af;">{order.order_number}</td></tr>'
-                f'{iban_row}'
+                f"{iban_row}"
                 f'<tr><td style="padding:4px 16px 14px;font-size:13px;color:#64748b;">Suma na úhradu:</td>'
                 f'<td style="padding:4px 16px 14px 8px;font-size:15px;font-weight:700;color:#1d4ed8;">{order.total_price}&nbsp;&euro;</td></tr>'
-                '</table>'
+                "</table>"
             )
 
         company_block = ""
@@ -330,7 +331,8 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
             dic_dph_row = (
                 f'<tr><td style="padding:3px 16px;font-size:13px;color:#64748b;">IČ DPH:</td>'
                 f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.dic_dph}</td></tr>'
-                if order.dic_dph else ""
+                if order.dic_dph
+                else ""
             )
             company_block = (
                 '<table width="100%" cellpadding="0" cellspacing="0"'
@@ -342,17 +344,18 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.ico}</td></tr>'
                 f'<tr><td style="padding:3px 16px;font-size:13px;color:#64748b;">DIČ:</td>'
                 f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.dic}</td></tr>'
-                f'{dic_dph_row}'
+                f"{dic_dph_row}"
                 '<tr><td colspan="2" style="padding:8px 16px 14px;"></td></tr>'
-                '</table>'
+                "</table>"
             )
 
         notes_block = (
             '<table width="100%" cellpadding="0" cellspacing="0"'
             ' style="background:#fffbeb;border-left:3px solid #f59e0b;border-radius:0 4px 4px 0;margin-bottom:16px;border-collapse:collapse;">'
             f'<tr><td style="padding:12px 16px;font-size:13px;color:#78350f;"><strong>Poznámka:</strong> {order.notes}</td></tr>'
-            '</table>'
-            if order.notes else ""
+            "</table>"
+            if order.notes
+            else ""
         )
 
         return f"""<!DOCTYPE html>
@@ -454,8 +457,8 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
             bg = "#fff7f7" if is_low else ("#ffffff" if i % 2 == 0 else "#f8fafc")
             stock_cell = (
                 '<span style="background:#fee2e2;color:#dc2626;padding:3px 10px;border-radius:12px;font-size:11px;font-weight:700;">&#x26A0; NÍZKY STAV</span>'
-                if is_low else
-                '<span style="color:#16a34a;font-size:12px;font-weight:600;">&#x2713; OK</span>'
+                if is_low
+                else '<span style="color:#16a34a;font-size:12px;font-weight:600;">&#x2713; OK</span>'
             )
             qty_color = "#dc2626" if is_low else "#374151"
             item_rows += (
@@ -465,7 +468,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 f'<td style="padding:10px 12px;font-size:13px;font-weight:700;color:#1e293b;text-align:center;border-bottom:1px solid #f1f5f9;">{item.quantity}</td>'
                 f'<td style="padding:10px 12px;font-size:13px;font-weight:700;color:{qty_color};text-align:center;border-bottom:1px solid #f1f5f9;">{remaining}&nbsp;ks</td>'
                 f'<td style="padding:10px 12px;text-align:center;border-bottom:1px solid #f1f5f9;">{stock_cell}</td>'
-                '</tr>'
+                "</tr>"
             )
 
         company_block = ""
@@ -473,7 +476,8 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
             dic_dph_row = (
                 f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">IČ DPH:</td>'
                 f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.dic_dph}</td></tr>'
-                if order.dic_dph else ""
+                if order.dic_dph
+                else ""
             )
             company_block = (
                 '<table width="100%" cellpadding="0" cellspacing="0"'
@@ -485,18 +489,19 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.ico}</td></tr>'
                 f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">DIČ:</td>'
                 f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.dic}</td></tr>'
-                f'{dic_dph_row}'
+                f"{dic_dph_row}"
                 '<tr><td colspan="2" style="padding:4px 16px 12px;"></td></tr>'
-                '</table>'
+                "</table>"
             )
 
         notes_block = (
             '<table width="100%" cellpadding="0" cellspacing="0"'
             ' style="background:#fffbeb;border-left:3px solid #f59e0b;border-radius:0 4px 4px 0;margin-top:16px;border-collapse:collapse;">'
             f'<tr><td style="padding:12px 16px;font-size:13px;color:#78350f;">'
-            f'<strong>Poznámka zákazníka:</strong> {order.notes}'
-            '</td></tr></table>'
-            if order.notes else ""
+            f"<strong>Poznámka zákazníka:</strong> {order.notes}"
+            "</td></tr></table>"
+            if order.notes
+            else ""
         )
 
         return f"""<!DOCTYPE html>

--- a/backend/orders/serializers.py
+++ b/backend/orders/serializers.py
@@ -8,6 +8,7 @@ import uuid
 from django.db import transaction
 from django.core.mail import EmailMultiAlternatives
 from django.conf import settings
+from django.utils.html import escape
 from users.models import GlobalSettings
 from .invoice import generate_invoice_pdf
 
@@ -293,23 +294,24 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
 
     def _build_customer_email_html(self, order, shop) -> str:
         """Build HTML version of customer order confirmation email."""
-        item_rows = ""
+        row_parts = []
         for i, item in enumerate(order.items.select_related("product").all()):
             bg = "#ffffff" if i % 2 == 0 else "#f8fafc"
-            item_rows += (
+            row_parts.append(
                 f'<tr style="background:{bg};">'
-                f'<td style="padding:10px 12px;font-size:14px;color:#1e293b;border-bottom:1px solid #f1f5f9;">{item.product.name}</td>'
+                f'<td style="padding:10px 12px;font-size:14px;color:#1e293b;border-bottom:1px solid #f1f5f9;">{escape(item.product.name)}</td>'
                 f'<td style="padding:10px 12px;font-size:14px;color:#475569;text-align:center;border-bottom:1px solid #f1f5f9;">{item.quantity}</td>'
                 f'<td style="padding:10px 12px;font-size:14px;color:#475569;text-align:right;border-bottom:1px solid #f1f5f9;">{item.price_snapshot}&nbsp;&euro;</td>'
                 f'<td style="padding:10px 12px;font-size:14px;font-weight:600;color:#1e293b;text-align:right;border-bottom:1px solid #f1f5f9;">{item.get_subtotal()}&nbsp;&euro;</td>'
                 "</tr>"
             )
+        item_rows = "".join(row_parts)
 
         payment_block = ""
         if order.payment_method == "bank_transfer":
             iban_row = (
                 f'<tr><td style="padding:4px 16px;font-size:13px;color:#64748b;">IBAN:</td>'
-                f'<td style="padding:4px 16px 4px 8px;font-size:13px;font-weight:600;color:#1e293b;">{shop.iban}</td></tr>'
+                f'<td style="padding:4px 16px 4px 8px;font-size:13px;font-weight:600;color:#1e293b;">{escape(shop.iban)}</td></tr>'
                 if shop.iban
                 else ""
             )
@@ -319,7 +321,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 '<tr><td colspan="2" style="padding:14px 16px 8px;font-size:11px;font-weight:700;color:#1d4ed8;'
                 'text-transform:uppercase;letter-spacing:0.8px;">Platobné údaje</td></tr>'
                 f'<tr><td style="padding:4px 16px;font-size:13px;color:#64748b;">Variabilný symbol:</td>'
-                f'<td style="padding:4px 16px 4px 8px;font-size:13px;font-weight:700;color:#1e40af;">{order.order_number}</td></tr>'
+                f'<td style="padding:4px 16px 4px 8px;font-size:13px;font-weight:700;color:#1e40af;">{escape(order.order_number)}</td></tr>'
                 f"{iban_row}"
                 f'<tr><td style="padding:4px 16px 14px;font-size:13px;color:#64748b;">Suma na úhradu:</td>'
                 f'<td style="padding:4px 16px 14px 8px;font-size:15px;font-weight:700;color:#1d4ed8;">{order.total_price}&nbsp;&euro;</td></tr>'
@@ -330,7 +332,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
         if order.is_company:
             dic_dph_row = (
                 f'<tr><td style="padding:3px 16px;font-size:13px;color:#64748b;">IČ DPH:</td>'
-                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.dic_dph}</td></tr>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{escape(order.dic_dph)}</td></tr>'
                 if order.dic_dph
                 else ""
             )
@@ -339,11 +341,11 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 ' style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;margin-bottom:16px;border-collapse:collapse;">'
                 '<tr><td colspan="2" style="padding:14px 16px 8px;font-size:11px;font-weight:700;color:#374151;'
                 'text-transform:uppercase;letter-spacing:0.8px;">Fakturačné údaje</td></tr>'
-                f'<tr><td colspan="2" style="padding:4px 16px;font-size:14px;font-weight:600;color:#1e293b;">{order.company_name}</td></tr>'
+                f'<tr><td colspan="2" style="padding:4px 16px;font-size:14px;font-weight:600;color:#1e293b;">{escape(order.company_name)}</td></tr>'
                 f'<tr><td style="padding:3px 16px;font-size:13px;color:#64748b;">IČO:</td>'
-                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.ico}</td></tr>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{escape(order.ico)}</td></tr>'
                 f'<tr><td style="padding:3px 16px;font-size:13px;color:#64748b;">DIČ:</td>'
-                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.dic}</td></tr>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{escape(order.dic)}</td></tr>'
                 f"{dic_dph_row}"
                 '<tr><td colspan="2" style="padding:8px 16px 14px;"></td></tr>'
                 "</table>"
@@ -352,7 +354,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
         notes_block = (
             '<table width="100%" cellpadding="0" cellspacing="0"'
             ' style="background:#fffbeb;border-left:3px solid #f59e0b;border-radius:0 4px 4px 0;margin-bottom:16px;border-collapse:collapse;">'
-            f'<tr><td style="padding:12px 16px;font-size:13px;color:#78350f;"><strong>Poznámka:</strong> {order.notes}</td></tr>'
+            f'<tr><td style="padding:12px 16px;font-size:13px;color:#78350f;"><strong>Poznámka:</strong> {escape(order.notes)}</td></tr>'
             "</table>"
             if order.notes
             else ""
@@ -377,13 +379,13 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
         </tr>
         <tr>
           <td style="padding:32px 40px;">
-            <p style="font-size:16px;color:#1e293b;margin:0 0 6px;">Dobrý deň, <strong>{order.customer_name}</strong>,</p>
+            <p style="font-size:16px;color:#1e293b;margin:0 0 6px;">Dobrý deň, <strong>{escape(order.customer_name)}</strong>,</p>
             <p style="color:#475569;margin:0 0 28px;font-size:14px;line-height:1.7;">Ďakujeme za Vašu objednávku v DentalShop! Nižšie nájdete jej kompletný prehľad. Faktúra vo formáte PDF je priložená k tomuto e-mailu.</p>
             <table width="100%" cellpadding="0" cellspacing="0" style="background:#eff6ff;border-left:4px solid #2563eb;border-radius:0 6px 6px 0;margin-bottom:28px;">
               <tr>
                 <td style="padding:14px 18px;">
                   <span style="font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:0.8px;font-weight:600;">Číslo objednávky</span><br>
-                  <strong style="font-size:22px;color:#1e40af;letter-spacing:1px;"># {order.order_number}</strong>
+                  <strong style="font-size:22px;color:#1e40af;letter-spacing:1px;"># {escape(order.order_number)}</strong>
                 </td>
                 <td style="padding:14px 18px;text-align:right;vertical-align:middle;">
                   <span style="background:#dbeafe;color:#1d4ed8;padding:5px 14px;border-radius:20px;font-size:12px;font-weight:600;">{order.get_status_display()}</span>
@@ -414,10 +416,10 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                   <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 8px;text-transform:uppercase;letter-spacing:0.8px;">Dodacia adresa</p>
                   <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;border-collapse:collapse;">
                     <tr><td style="padding:14px 16px;font-size:13px;color:#374151;line-height:1.9;">
-                      <strong style="color:#1e293b;">{order.customer_name}</strong><br>
-                      {order.street}<br>
-                      {order.city}, {order.postal_code}<br>
-                      <span style="color:#64748b;">Tel: {order.phone}</span>
+                      <strong style="color:#1e293b;">{escape(order.customer_name)}</strong><br>
+                      {escape(order.street)}<br>
+                      {escape(order.city)}, {escape(order.postal_code)}<br>
+                      <span style="color:#64748b;">Tel: {escape(order.phone)}</span>
                     </td></tr>
                   </table>
                 </td>
@@ -449,7 +451,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
 
     def _build_warehouse_email_html(self, order) -> str:
         """Build HTML version of warehouse order notification email."""
-        item_rows = ""
+        row_parts = []
         for i, item in enumerate(order.items.select_related("product").all()):
             remaining = item.product.stock_quantity
             threshold = item.product.low_stock_threshold
@@ -461,15 +463,16 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 else '<span style="color:#16a34a;font-size:12px;font-weight:600;">&#x2713; OK</span>'
             )
             qty_color = "#dc2626" if is_low else "#374151"
-            item_rows += (
+            row_parts.append(
                 f'<tr style="background:{bg};">'
                 f'<td style="padding:10px 12px;font-size:13px;color:#1e293b;border-bottom:1px solid #f1f5f9;">'
-                f'{item.product.name}<br><span style="font-size:11px;color:#94a3b8;">ID: {item.product.id}</span></td>'
+                f'{escape(item.product.name)}<br><span style="font-size:11px;color:#94a3b8;">ID: {item.product.id}</span></td>'
                 f'<td style="padding:10px 12px;font-size:13px;font-weight:700;color:#1e293b;text-align:center;border-bottom:1px solid #f1f5f9;">{item.quantity}</td>'
                 f'<td style="padding:10px 12px;font-size:13px;font-weight:700;color:{qty_color};text-align:center;border-bottom:1px solid #f1f5f9;">{remaining}&nbsp;ks</td>'
                 f'<td style="padding:10px 12px;text-align:center;border-bottom:1px solid #f1f5f9;">{stock_cell}</td>'
                 "</tr>"
             )
+        item_rows = "".join(row_parts)
 
         company_block = ""
         if order.is_company:
@@ -479,16 +482,22 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 if order.dic_dph
                 else ""
             )
+            dic_dph_row = (
+                f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">IČ DPH:</td>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{escape(order.dic_dph)}</td></tr>'
+                if order.dic_dph
+                else ""
+            )
             company_block = (
                 '<table width="100%" cellpadding="0" cellspacing="0"'
                 ' style="background:#fffbeb;border:1px solid #fde68a;border-radius:6px;margin-bottom:20px;border-collapse:collapse;">'
                 '<tr><td colspan="2" style="padding:12px 16px 8px;font-size:11px;font-weight:700;color:#92400e;'
                 'text-transform:uppercase;letter-spacing:0.8px;">Firemná objednávka</td></tr>'
-                f'<tr><td colspan="2" style="padding:4px 16px;font-size:14px;font-weight:600;color:#1e293b;">{order.company_name}</td></tr>'
+                f'<tr><td colspan="2" style="padding:4px 16px;font-size:14px;font-weight:600;color:#1e293b;">{escape(order.company_name)}</td></tr>'
                 f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">IČO:</td>'
-                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.ico}</td></tr>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{escape(order.ico)}</td></tr>'
                 f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">DIČ:</td>'
-                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.dic}</td></tr>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{escape(order.dic)}</td></tr>'
                 f"{dic_dph_row}"
                 '<tr><td colspan="2" style="padding:4px 16px 12px;"></td></tr>'
                 "</table>"
@@ -498,7 +507,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
             '<table width="100%" cellpadding="0" cellspacing="0"'
             ' style="background:#fffbeb;border-left:3px solid #f59e0b;border-radius:0 4px 4px 0;margin-top:16px;border-collapse:collapse;">'
             f'<tr><td style="padding:12px 16px;font-size:13px;color:#78350f;">'
-            f"<strong>Poznámka zákazníka:</strong> {order.notes}"
+            f"<strong>Poznámka zákazníka:</strong> {escape(order.notes)}"
             "</td></tr></table>"
             if order.notes
             else ""
@@ -536,17 +545,17 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
               <tr>
                 <td width="50%" style="padding:14px 16px;border-right:1px solid #e2e8f0;border-bottom:1px solid #e2e8f0;">
                   <p style="margin:0 0 3px;font-size:11px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;">Meno</p>
-                  <p style="margin:0;font-size:14px;font-weight:600;color:#1e293b;">{order.customer_name}</p>
+                  <p style="margin:0;font-size:14px;font-weight:600;color:#1e293b;">{escape(order.customer_name)}</p>
                 </td>
                 <td width="50%" style="padding:14px 16px;border-bottom:1px solid #e2e8f0;">
                   <p style="margin:0 0 3px;font-size:11px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;">Telefón</p>
-                  <p style="margin:0;font-size:14px;font-weight:600;color:#1e293b;">{order.phone}</p>
+                  <p style="margin:0;font-size:14px;font-weight:600;color:#1e293b;">{escape(order.phone)}</p>
                 </td>
               </tr>
               <tr>
                 <td colspan="2" style="padding:14px 16px;">
                   <p style="margin:0 0 3px;font-size:11px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;">Email</p>
-                  <p style="margin:0;font-size:14px;color:#2563eb;">{order.email}</p>
+                  <p style="margin:0;font-size:14px;color:#2563eb;">{escape(order.email)}</p>
                 </td>
               </tr>
             </table>
@@ -556,7 +565,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                   <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 8px;text-transform:uppercase;letter-spacing:0.8px;">Dodacia adresa</p>
                   <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;border-collapse:collapse;">
                     <tr><td style="padding:14px 16px;font-size:13px;color:#374151;line-height:1.9;">
-                      {order.street}<br>{order.city}, {order.postal_code}
+                      {escape(order.street)}<br>{escape(order.city)}, {escape(order.postal_code)}
                     </td></tr>
                   </table>
                 </td>

--- a/backend/orders/serializers.py
+++ b/backend/orders/serializers.py
@@ -478,12 +478,6 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
         if order.is_company:
             dic_dph_row = (
                 f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">IČ DPH:</td>'
-                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.dic_dph}</td></tr>'
-                if order.dic_dph
-                else ""
-            )
-            dic_dph_row = (
-                f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">IČ DPH:</td>'
                 f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{escape(order.dic_dph)}</td></tr>'
                 if order.dic_dph
                 else ""
@@ -532,7 +526,7 @@ Poznámka zákazníka: {order.notes or "Žiadna"}
                 <h1 style="color:#ffffff;margin:4px 0 0;font-size:22px;font-weight:700;">Nová objednávka</h1>
               </td>
               <td style="text-align:right;vertical-align:middle;">
-                <span style="background:#2563eb;color:#ffffff;padding:6px 16px;border-radius:20px;font-size:14px;font-weight:700;"># {order.order_number}</span>
+                <span style="background:#2563eb;color:#ffffff;padding:6px 16px;border-radius:20px;font-size:14px;font-weight:700;"># {escape(order.order_number)}</span>
               </td>
             </tr></table>
           </td>

--- a/backend/orders/serializers.py
+++ b/backend/orders/serializers.py
@@ -6,7 +6,7 @@ from products.models import Product
 from decimal import Decimal
 import uuid
 from django.db import transaction
-from django.core.mail import EmailMessage
+from django.core.mail import EmailMultiAlternatives
 from django.conf import settings
 from users.models import GlobalSettings
 from .invoice import generate_invoice_pdf
@@ -151,7 +151,7 @@ class OrderCreateSerializer(serializers.ModelSerializer):
             return order
 
     def _send_order_emails(self, order):
-        """Send confirmation emails (with PDF invoice) to customer and warehouse."""
+        """Send HTML confirmation emails (with PDF invoice) to customer and warehouse."""
         shop = GlobalSettings.load()
         try:
             pdf_bytes = generate_invoice_pdf(order, shop)
@@ -163,13 +163,14 @@ class OrderCreateSerializer(serializers.ModelSerializer):
 
         filename = f"faktura_{order.order_number}.pdf"
 
-        def _make_email(subject, body, to):
-            msg = EmailMessage(
+        def _make_email(subject, text_body, html_body, to):
+            msg = EmailMultiAlternatives(
                 subject=subject,
-                body=body,
+                body=text_body,
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 to=[to],
             )
+            msg.attach_alternative(html_body, "text/html")
             if pdf_bytes:
                 msg.attach(filename, pdf_bytes, "application/pdf")
             return msg
@@ -179,12 +180,14 @@ class OrderCreateSerializer(serializers.ModelSerializer):
         _make_email(
             f"Potvrdenie objednávky #{order.order_number}",
             self._build_customer_email(order, shop),
+            self._build_customer_email_html(order, shop),
             order.email,
         ).send(fail_silently=True)
 
         _make_email(
             f"Nová objednávka #{order.order_number}",
             self._build_warehouse_email(order),
+            self._build_warehouse_email_html(order),
             warehouse_email,
         ).send(fail_silently=True)
 
@@ -287,6 +290,309 @@ Stav: {order.get_status_display()}
 
 Poznámka zákazníka: {order.notes or "Žiadna"}
 """
+
+    def _build_customer_email_html(self, order, shop) -> str:
+        """Build HTML version of customer order confirmation email."""
+        item_rows = ""
+        for i, item in enumerate(order.items.select_related("product").all()):
+            bg = "#ffffff" if i % 2 == 0 else "#f8fafc"
+            item_rows += (
+                f'<tr style="background:{bg};">'
+                f'<td style="padding:10px 12px;font-size:14px;color:#1e293b;border-bottom:1px solid #f1f5f9;">{item.product.name}</td>'
+                f'<td style="padding:10px 12px;font-size:14px;color:#475569;text-align:center;border-bottom:1px solid #f1f5f9;">{item.quantity}</td>'
+                f'<td style="padding:10px 12px;font-size:14px;color:#475569;text-align:right;border-bottom:1px solid #f1f5f9;">{item.price_snapshot}&nbsp;&euro;</td>'
+                f'<td style="padding:10px 12px;font-size:14px;font-weight:600;color:#1e293b;text-align:right;border-bottom:1px solid #f1f5f9;">{item.get_subtotal()}&nbsp;&euro;</td>'
+                '</tr>'
+            )
+
+        payment_block = ""
+        if order.payment_method == "bank_transfer":
+            iban_row = (
+                f'<tr><td style="padding:4px 16px;font-size:13px;color:#64748b;">IBAN:</td>'
+                f'<td style="padding:4px 16px 4px 8px;font-size:13px;font-weight:600;color:#1e293b;">{shop.iban}</td></tr>'
+                if shop.iban else ""
+            )
+            payment_block = (
+                '<table width="100%" cellpadding="0" cellspacing="0"'
+                ' style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:6px;margin-bottom:16px;border-collapse:collapse;">'
+                '<tr><td colspan="2" style="padding:14px 16px 8px;font-size:11px;font-weight:700;color:#1d4ed8;'
+                'text-transform:uppercase;letter-spacing:0.8px;">Platobné údaje</td></tr>'
+                f'<tr><td style="padding:4px 16px;font-size:13px;color:#64748b;">Variabilný symbol:</td>'
+                f'<td style="padding:4px 16px 4px 8px;font-size:13px;font-weight:700;color:#1e40af;">{order.order_number}</td></tr>'
+                f'{iban_row}'
+                f'<tr><td style="padding:4px 16px 14px;font-size:13px;color:#64748b;">Suma na úhradu:</td>'
+                f'<td style="padding:4px 16px 14px 8px;font-size:15px;font-weight:700;color:#1d4ed8;">{order.total_price}&nbsp;&euro;</td></tr>'
+                '</table>'
+            )
+
+        company_block = ""
+        if order.is_company:
+            dic_dph_row = (
+                f'<tr><td style="padding:3px 16px;font-size:13px;color:#64748b;">IČ DPH:</td>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.dic_dph}</td></tr>'
+                if order.dic_dph else ""
+            )
+            company_block = (
+                '<table width="100%" cellpadding="0" cellspacing="0"'
+                ' style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;margin-bottom:16px;border-collapse:collapse;">'
+                '<tr><td colspan="2" style="padding:14px 16px 8px;font-size:11px;font-weight:700;color:#374151;'
+                'text-transform:uppercase;letter-spacing:0.8px;">Fakturačné údaje</td></tr>'
+                f'<tr><td colspan="2" style="padding:4px 16px;font-size:14px;font-weight:600;color:#1e293b;">{order.company_name}</td></tr>'
+                f'<tr><td style="padding:3px 16px;font-size:13px;color:#64748b;">IČO:</td>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.ico}</td></tr>'
+                f'<tr><td style="padding:3px 16px;font-size:13px;color:#64748b;">DIČ:</td>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:13px;color:#1e293b;">{order.dic}</td></tr>'
+                f'{dic_dph_row}'
+                '<tr><td colspan="2" style="padding:8px 16px 14px;"></td></tr>'
+                '</table>'
+            )
+
+        notes_block = (
+            '<table width="100%" cellpadding="0" cellspacing="0"'
+            ' style="background:#fffbeb;border-left:3px solid #f59e0b;border-radius:0 4px 4px 0;margin-bottom:16px;border-collapse:collapse;">'
+            f'<tr><td style="padding:12px 16px;font-size:13px;color:#78350f;"><strong>Poznámka:</strong> {order.notes}</td></tr>'
+            '</table>'
+            if order.notes else ""
+        )
+
+        return f"""<!DOCTYPE html>
+<html lang="sk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Potvrdenie objednávky</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f6f9;font-family:Arial,Helvetica,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f6f9;padding:30px 16px;">
+    <tr><td align="center">
+      <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.10);">
+        <tr>
+          <td style="background:#2563eb;padding:28px 40px;text-align:center;">
+            <h1 style="color:#ffffff;margin:0;font-size:26px;font-weight:700;">DentalShop</h1>
+            <p style="color:#bfdbfe;margin:8px 0 0;font-size:14px;">Potvrdenie objednávky</p>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:32px 40px;">
+            <p style="font-size:16px;color:#1e293b;margin:0 0 6px;">Dobrý deň, <strong>{order.customer_name}</strong>,</p>
+            <p style="color:#475569;margin:0 0 28px;font-size:14px;line-height:1.7;">Ďakujeme za Vašu objednávku v DentalShop! Nižšie nájdete jej kompletný prehľad. Faktúra vo formáte PDF je priložená k tomuto e-mailu.</p>
+            <table width="100%" cellpadding="0" cellspacing="0" style="background:#eff6ff;border-left:4px solid #2563eb;border-radius:0 6px 6px 0;margin-bottom:28px;">
+              <tr>
+                <td style="padding:14px 18px;">
+                  <span style="font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:0.8px;font-weight:600;">Číslo objednávky</span><br>
+                  <strong style="font-size:22px;color:#1e40af;letter-spacing:1px;"># {order.order_number}</strong>
+                </td>
+                <td style="padding:14px 18px;text-align:right;vertical-align:middle;">
+                  <span style="background:#dbeafe;color:#1d4ed8;padding:5px 14px;border-radius:20px;font-size:12px;font-weight:600;">{order.get_status_display()}</span>
+                </td>
+              </tr>
+            </table>
+            <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 10px;text-transform:uppercase;letter-spacing:0.8px;">Objednané produkty</p>
+            <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;border:1px solid #e2e8f0;border-radius:6px;overflow:hidden;margin-bottom:24px;">
+              <thead>
+                <tr style="background:#f8fafc;">
+                  <th style="padding:10px 12px;text-align:left;font-size:11px;color:#64748b;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;border-bottom:2px solid #e2e8f0;">Produkt</th>
+                  <th style="padding:10px 12px;text-align:center;font-size:11px;color:#64748b;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;border-bottom:2px solid #e2e8f0;">Množ.</th>
+                  <th style="padding:10px 12px;text-align:right;font-size:11px;color:#64748b;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;border-bottom:2px solid #e2e8f0;">Cena/ks</th>
+                  <th style="padding:10px 12px;text-align:right;font-size:11px;color:#64748b;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;border-bottom:2px solid #e2e8f0;">Spolu</th>
+                </tr>
+              </thead>
+              <tbody>{item_rows}</tbody>
+              <tfoot>
+                <tr style="background:#f8fafc;">
+                  <td colspan="3" style="padding:12px;text-align:right;font-weight:700;color:#1e293b;font-size:14px;border-top:2px solid #e2e8f0;">Celková suma:</td>
+                  <td style="padding:12px;text-align:right;font-weight:700;color:#1d4ed8;font-size:16px;border-top:2px solid #e2e8f0;">{order.total_price}&nbsp;&euro;</td>
+                </tr>
+              </tfoot>
+            </table>
+            <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:20px;">
+              <tr>
+                <td width="48%" valign="top" style="padding-right:10px;">
+                  <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 8px;text-transform:uppercase;letter-spacing:0.8px;">Dodacia adresa</p>
+                  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;border-collapse:collapse;">
+                    <tr><td style="padding:14px 16px;font-size:13px;color:#374151;line-height:1.9;">
+                      <strong style="color:#1e293b;">{order.customer_name}</strong><br>
+                      {order.street}<br>
+                      {order.city}, {order.postal_code}<br>
+                      <span style="color:#64748b;">Tel: {order.phone}</span>
+                    </td></tr>
+                  </table>
+                </td>
+                <td width="4%">&nbsp;</td>
+                <td width="48%" valign="top" style="padding-left:10px;">
+                  <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 8px;text-transform:uppercase;letter-spacing:0.8px;">Spôsob platby</p>
+                  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;border-collapse:collapse;">
+                    <tr><td style="padding:14px 16px;font-size:13px;color:#374151;">
+                      <strong style="color:#1e293b;">{order.get_payment_method_display()}</strong>
+                    </td></tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+            {payment_block}{company_block}{notes_block}
+          </td>
+        </tr>
+        <tr>
+          <td style="background:#f8fafc;padding:20px 40px;text-align:center;border-top:1px solid #e2e8f0;">
+            <p style="margin:0 0 4px;font-size:13px;color:#94a3b8;">V prípade otázok nás neváhajte kontaktovať.</p>
+            <p style="margin:0;font-size:13px;color:#64748b;font-weight:600;">Tím DentalShop</p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
+
+    def _build_warehouse_email_html(self, order) -> str:
+        """Build HTML version of warehouse order notification email."""
+        item_rows = ""
+        for i, item in enumerate(order.items.select_related("product").all()):
+            remaining = item.product.stock_quantity
+            threshold = item.product.low_stock_threshold
+            is_low = remaining < threshold
+            bg = "#fff7f7" if is_low else ("#ffffff" if i % 2 == 0 else "#f8fafc")
+            stock_cell = (
+                '<span style="background:#fee2e2;color:#dc2626;padding:3px 10px;border-radius:12px;font-size:11px;font-weight:700;">&#x26A0; NÍZKY STAV</span>'
+                if is_low else
+                '<span style="color:#16a34a;font-size:12px;font-weight:600;">&#x2713; OK</span>'
+            )
+            qty_color = "#dc2626" if is_low else "#374151"
+            item_rows += (
+                f'<tr style="background:{bg};">'
+                f'<td style="padding:10px 12px;font-size:13px;color:#1e293b;border-bottom:1px solid #f1f5f9;">'
+                f'{item.product.name}<br><span style="font-size:11px;color:#94a3b8;">ID: {item.product.id}</span></td>'
+                f'<td style="padding:10px 12px;font-size:13px;font-weight:700;color:#1e293b;text-align:center;border-bottom:1px solid #f1f5f9;">{item.quantity}</td>'
+                f'<td style="padding:10px 12px;font-size:13px;font-weight:700;color:{qty_color};text-align:center;border-bottom:1px solid #f1f5f9;">{remaining}&nbsp;ks</td>'
+                f'<td style="padding:10px 12px;text-align:center;border-bottom:1px solid #f1f5f9;">{stock_cell}</td>'
+                '</tr>'
+            )
+
+        company_block = ""
+        if order.is_company:
+            dic_dph_row = (
+                f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">IČ DPH:</td>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.dic_dph}</td></tr>'
+                if order.dic_dph else ""
+            )
+            company_block = (
+                '<table width="100%" cellpadding="0" cellspacing="0"'
+                ' style="background:#fffbeb;border:1px solid #fde68a;border-radius:6px;margin-bottom:20px;border-collapse:collapse;">'
+                '<tr><td colspan="2" style="padding:12px 16px 8px;font-size:11px;font-weight:700;color:#92400e;'
+                'text-transform:uppercase;letter-spacing:0.8px;">Firemná objednávka</td></tr>'
+                f'<tr><td colspan="2" style="padding:4px 16px;font-size:14px;font-weight:600;color:#1e293b;">{order.company_name}</td></tr>'
+                f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">IČO:</td>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.ico}</td></tr>'
+                f'<tr><td style="padding:3px 16px;font-size:12px;color:#64748b;">DIČ:</td>'
+                f'<td style="padding:3px 16px 3px 8px;font-size:12px;color:#1e293b;">{order.dic}</td></tr>'
+                f'{dic_dph_row}'
+                '<tr><td colspan="2" style="padding:4px 16px 12px;"></td></tr>'
+                '</table>'
+            )
+
+        notes_block = (
+            '<table width="100%" cellpadding="0" cellspacing="0"'
+            ' style="background:#fffbeb;border-left:3px solid #f59e0b;border-radius:0 4px 4px 0;margin-top:16px;border-collapse:collapse;">'
+            f'<tr><td style="padding:12px 16px;font-size:13px;color:#78350f;">'
+            f'<strong>Poznámka zákazníka:</strong> {order.notes}'
+            '</td></tr></table>'
+            if order.notes else ""
+        )
+
+        return f"""<!DOCTYPE html>
+<html lang="sk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Nová objednávka #{order.order_number}</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f6f9;font-family:Arial,Helvetica,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f6f9;padding:30px 16px;">
+    <tr><td align="center">
+      <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.10);">
+        <tr>
+          <td style="background:#0f172a;padding:24px 40px;">
+            <table width="100%" cellpadding="0" cellspacing="0"><tr>
+              <td>
+                <p style="margin:0;font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:1px;">DentalShop &middot; Sklad</p>
+                <h1 style="color:#ffffff;margin:4px 0 0;font-size:22px;font-weight:700;">Nová objednávka</h1>
+              </td>
+              <td style="text-align:right;vertical-align:middle;">
+                <span style="background:#2563eb;color:#ffffff;padding:6px 16px;border-radius:20px;font-size:14px;font-weight:700;"># {order.order_number}</span>
+              </td>
+            </tr></table>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:28px 40px;">
+            {company_block}
+            <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 10px;text-transform:uppercase;letter-spacing:0.8px;">Zákazník</p>
+            <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;margin-bottom:24px;border-collapse:collapse;">
+              <tr>
+                <td width="50%" style="padding:14px 16px;border-right:1px solid #e2e8f0;border-bottom:1px solid #e2e8f0;">
+                  <p style="margin:0 0 3px;font-size:11px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;">Meno</p>
+                  <p style="margin:0;font-size:14px;font-weight:600;color:#1e293b;">{order.customer_name}</p>
+                </td>
+                <td width="50%" style="padding:14px 16px;border-bottom:1px solid #e2e8f0;">
+                  <p style="margin:0 0 3px;font-size:11px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;">Telefón</p>
+                  <p style="margin:0;font-size:14px;font-weight:600;color:#1e293b;">{order.phone}</p>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2" style="padding:14px 16px;">
+                  <p style="margin:0 0 3px;font-size:11px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.5px;">Email</p>
+                  <p style="margin:0;font-size:14px;color:#2563eb;">{order.email}</p>
+                </td>
+              </tr>
+            </table>
+            <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
+              <tr>
+                <td width="48%" valign="top" style="padding-right:10px;">
+                  <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 8px;text-transform:uppercase;letter-spacing:0.8px;">Dodacia adresa</p>
+                  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;border-collapse:collapse;">
+                    <tr><td style="padding:14px 16px;font-size:13px;color:#374151;line-height:1.9;">
+                      {order.street}<br>{order.city}, {order.postal_code}
+                    </td></tr>
+                  </table>
+                </td>
+                <td width="4%">&nbsp;</td>
+                <td width="48%" valign="top" style="padding-left:10px;">
+                  <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 8px;text-transform:uppercase;letter-spacing:0.8px;">Platba &amp; stav</p>
+                  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:6px;border-collapse:collapse;">
+                    <tr><td style="padding:14px 16px;font-size:13px;color:#374151;line-height:1.9;">
+                      <strong style="color:#1e293b;">{order.get_payment_method_display()}</strong><br>
+                      <span style="color:#64748b;">{order.get_status_display()}</span><br>
+                      <strong style="font-size:16px;color:#1d4ed8;">{order.total_price}&nbsp;&euro;</strong>
+                    </td></tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+            <p style="font-size:11px;font-weight:700;color:#94a3b8;margin:0 0 10px;text-transform:uppercase;letter-spacing:0.8px;">Produkty na vyskladnenie</p>
+            <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;border:1px solid #e2e8f0;border-radius:6px;overflow:hidden;">
+              <thead>
+                <tr style="background:#0f172a;">
+                  <th style="padding:10px 12px;text-align:left;font-size:11px;color:#94a3b8;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Produkt</th>
+                  <th style="padding:10px 12px;text-align:center;font-size:11px;color:#94a3b8;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Počet</th>
+                  <th style="padding:10px 12px;text-align:center;font-size:11px;color:#94a3b8;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Zostatok</th>
+                  <th style="padding:10px 12px;text-align:center;font-size:11px;color:#94a3b8;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;">Stav</th>
+                </tr>
+              </thead>
+              <tbody>{item_rows}</tbody>
+            </table>
+            {notes_block}
+          </td>
+        </tr>
+        <tr>
+          <td style="background:#0f172a;padding:16px 40px;text-align:center;">
+            <p style="margin:0;font-size:12px;color:#475569;">DentalShop &middot; Interná notifikácia</p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
 
 
 class OrderSerializer(serializers.ModelSerializer):

--- a/backend/products/management/commands/seed_products.py
+++ b/backend/products/management/commands/seed_products.py
@@ -33,8 +33,8 @@ class Command(BaseCommand):
 
         self.stdout.write("Seeding products...")
 
-        # Clear existing products
-        Product.objects.all().delete()
+        # Clear existing products that are not referenced by any orders
+        Product.objects.filter(orderitem__isnull=True).delete()
 
         categories = [
             "Implantáty",

--- a/backend/products/management/commands/seed_products.py
+++ b/backend/products/management/commands/seed_products.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         self.stdout.write("Seeding products...")
 
         # Clear existing products that are not referenced by any orders
-        Product.objects.filter(orderitem__isnull=True).delete()
+        Product.objects.filter(orderitem_set__isnull=True).delete()
 
         categories = [
             "Implantáty",

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -7,6 +7,12 @@ User = get_user_model()
 class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = User
+        skip_postgeneration_save = True
 
     email = factory.Sequence(lambda n: f"user{n}@example.com")
-    password = factory.PostGenerationMethodCall("set_password", "password123")
+
+    @factory.post_generation
+    def password(obj, create, extracted, **kwargs):
+        obj.set_password(extracted or "password123")
+        if create:
+            obj.save(update_fields=["password"])

--- a/backend/tests/users/test_auth.py
+++ b/backend/tests/users/test_auth.py
@@ -12,7 +12,7 @@ def test_use_registration(api_client):
     url = reverse("register")
     data = {
         "email": "newuser@example.com",
-        "password": "password123",
+        "password": "Xk7#mPqZ92",
     }
     response = api_client.post(url, data)
     assert response.status_code == status.HTTP_201_CREATED

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,4 +1,6 @@
 from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
 from .models import GlobalSettings
@@ -13,6 +15,16 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ("id", "email", "password")
+
+    def validate_password(self, value):
+        """Validate password using Django's validators."""
+        try:
+            # Create a temporary user object for validation context
+            temp_user = User(email=self.initial_data.get("email"))
+            validate_password(value, user=temp_user)
+        except ValidationError as e:
+            raise serializers.ValidationError(e.messages)
+        return value
 
     def create(self, validated_data):
         user = User.objects.create_user(

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
 from .models import GlobalSettings
-from .utils import send_verification_email
+from .utils import send_verification_email, _translate_password_errors
 
 User = get_user_model()
 
@@ -23,7 +23,7 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
             temp_user = User(email=self.initial_data.get("email"))
             validate_password(value, user=temp_user)
         except ValidationError as e:
-            raise serializers.ValidationError(e.messages)
+            raise serializers.ValidationError(_translate_password_errors(e))
         return value
 
     def create(self, validated_data):

--- a/backend/users/utils.py
+++ b/backend/users/utils.py
@@ -96,6 +96,113 @@ def _frontend_url() -> str:
     return os.environ.get("FRONTEND_URL", "http://localhost:5001").rstrip("/")
 
 
+def _verification_email_html(verify_url: str) -> str:
+    """HTML template for account verification email."""
+    return f"""<!DOCTYPE html>
+<html lang="sk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Overenie e-mailovej adresy</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f6f9;font-family:Arial,Helvetica,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f6f9;padding:40px 16px;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.10);">
+        <tr>
+          <td style="background:#2563eb;padding:28px 40px;text-align:center;">
+            <h1 style="color:#ffffff;margin:0;font-size:26px;font-weight:700;">DentalShop</h1>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:36px 40px;text-align:center;">
+            <h2 style="margin:0 0 12px;font-size:20px;color:#1e293b;">Overenie e-mailovej adresy</h2>
+            <p style="color:#475569;font-size:14px;line-height:1.7;margin:0 0 28px;">
+              Ďakujeme za Vašu registráciu na <strong>DentalShop</strong>!<br>
+              Pre dokončenie registrácie a aktiváciu Vášho účtu kliknite na tlačidlo nižšie.
+            </p>
+            <a href="{verify_url}" style="display:inline-block;background:#2563eb;color:#ffffff;text-decoration:none;padding:14px 32px;border-radius:6px;font-size:15px;font-weight:700;">
+              Overiť e-mailovú adresu
+            </a>
+            <p style="color:#94a3b8;font-size:12px;margin:24px 0 0;line-height:1.6;">
+              Ak tlačidlo nefunguje, skopírujte tento odkaz do prehliadača:<br>
+              <a href="{verify_url}" style="color:#2563eb;word-break:break-all;">{verify_url}</a>
+            </p>
+            <p style="color:#94a3b8;font-size:12px;margin:16px 0 0;">
+              Ak ste si účet nevytvárali, tento e-mail môžete ignorovať.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td style="background:#f8fafc;padding:18px 40px;text-align:center;border-top:1px solid #e2e8f0;">
+            <p style="margin:0;font-size:12px;color:#94a3b8;">S pozdravom, <strong style="color:#64748b;">Tím DentalShop</strong></p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
+
+
+def _password_reset_email_html(reset_url: str) -> str:
+    """HTML template for password reset email."""
+    return f"""<!DOCTYPE html>
+<html lang="sk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Obnovenie hesla</title>
+</head>
+<body style="margin:0;padding:0;background:#f4f6f9;font-family:Arial,Helvetica,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f6f9;padding:40px 16px;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.10);">
+        <tr>
+          <td style="background:#2563eb;padding:28px 40px;text-align:center;">
+            <h1 style="color:#ffffff;margin:0;font-size:26px;font-weight:700;">DentalShop</h1>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:36px 40px;text-align:center;">
+            <h2 style="margin:0 0 12px;font-size:20px;color:#1e293b;">Obnovenie hesla</h2>
+            <p style="color:#475569;font-size:14px;line-height:1.7;margin:0 0 28px;">
+              Dostali sme žiadosť o obnovenie hesla pre Váš účet.<br>
+              Kliknite na tlačidlo nižšie pre nastavenie nového hesla.
+            </p>
+            <a href="{reset_url}" style="display:inline-block;background:#2563eb;color:#ffffff;text-decoration:none;padding:14px 32px;border-radius:6px;font-size:15px;font-weight:700;">
+              Nastaviť nové heslo
+            </a>
+            <table width="100%" cellpadding="0" cellspacing="0" style="background:#fffbeb;border:1px solid #fde68a;border-radius:6px;margin:24px 0 0;border-collapse:collapse;">
+              <tr>
+                <td style="padding:12px 16px;">
+                  <p style="margin:0;font-size:13px;color:#92400e;">
+                    <strong>&#x26A0; Pozor:</strong> Tento odkaz je platný iba <strong>30 minút</strong>.
+                  </p>
+                </td>
+              </tr>
+            </table>
+            <p style="color:#94a3b8;font-size:12px;margin:20px 0 0;line-height:1.6;">
+              Ak tlačidlo nefunguje, skopírujte tento odkaz do prehliadača:<br>
+              <a href="{reset_url}" style="color:#2563eb;word-break:break-all;">{reset_url}</a>
+            </p>
+            <p style="color:#94a3b8;font-size:12px;margin:16px 0 0;">
+              Ak ste o obnovenie hesla nežiadali, tento e-mail môžete ignorovať — Vaše heslo zostane nezmenené.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td style="background:#f8fafc;padding:18px 40px;text-align:center;border-top:1px solid #e2e8f0;">
+            <p style="margin:0;font-size:12px;color:#94a3b8;">S pozdravom, <strong style="color:#64748b;">Tím DentalShop</strong></p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
+
+
 def send_verification_email(user) -> None:
     """Send (or resend) the e-mail verification link to *user*."""
     uid = urlsafe_base64_encode(force_bytes(user.pk))
@@ -119,6 +226,7 @@ def send_verification_email(user) -> None:
             getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@dentalshop.sk"),
             [user.email],
             fail_silently=False,
+            html_message=_verification_email_html(verify_url),
         )
     except Exception:
         logger.exception("[send_verification_email] Failed to send to %s", user.email)
@@ -149,6 +257,7 @@ def send_password_reset_email(user) -> None:
             getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@dentalshop.sk"),
             [user.email],
             fail_silently=False,
+            html_message=_password_reset_email_html(reset_url),
         )
     except Exception:
         logger.exception("[send_password_reset_email] Failed to send to %s", user.email)

--- a/backend/users/utils.py
+++ b/backend/users/utils.py
@@ -96,6 +96,22 @@ def _frontend_url() -> str:
     return os.environ.get("FRONTEND_URL", "http://localhost:5001").rstrip("/")
 
 
+_PASSWORD_ERRORS_SK = {
+    "password_too_short": "Heslo je príliš krátke. Musí mať aspoň 8 znakov.",
+    "password_too_common": "Toto heslo je príliš bežné.",
+    "password_entirely_numeric": "Heslo nesmí obsahovať iba číslice.",
+    "password_too_similar": "Heslo je príliš podobné Vaším osobným údajom.",
+}
+
+
+def _translate_password_errors(exc) -> str:
+    """Return a Slovak string summarising Django password ValidationError(s)."""
+    messages = [
+        _PASSWORD_ERRORS_SK.get(err.code, err.message) for err in exc.error_list
+    ]
+    return " ".join(messages)
+
+
 def _verification_email_html(verify_url: str) -> str:
     """HTML template for account verification email."""
     return f"""<!DOCTYPE html>

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -6,6 +6,8 @@ from django.contrib.auth import get_user_model
 from django.utils.http import urlsafe_base64_decode
 from django.utils.encoding import force_str
 from django.contrib.auth.tokens import default_token_generator
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 
 from .serializers import (
     UserRegistrationSerializer,
@@ -146,29 +148,32 @@ class PasswordResetConfirmView(views.APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        if len(new_password) < 8:
-            return Response(
-                {"error": "Heslo musí mať aspoň 8 znakov."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
         try:
             uid = force_str(urlsafe_base64_decode(uidb64))
             user = User.objects.get(pk=uid)
         except (TypeError, ValueError, OverflowError, User.DoesNotExist):
             user = None
 
-        if user is not None and default_token_generator.check_token(user, token):
-            user.set_password(new_password)
-            user.save()
-            return Response(
-                {"success": "Heslo bolo úspešne zmenené. Teraz sa môžete prihlásiť."}
-            )
-        else:
+        if user is None or not default_token_generator.check_token(user, token):
             return Response(
                 {"error": "Odkaz na obnovenie hesla je neplatný alebo expiroval."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        # Validate password using Django's validators
+        try:
+            validate_password(new_password, user=user)
+        except ValidationError as e:
+            return Response(
+                {"error": " ".join(e.messages)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user.set_password(new_password)
+        user.save()
+        return Response(
+            {"success": "Heslo bolo úspešne zmenené. Teraz sa môžete prihlásiť."}
+        )
 
 
 class MeView(generics.RetrieveUpdateDestroyAPIView):

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -9,6 +9,12 @@ from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 
+from .utils import (
+    check_and_record_rate_limit,
+    send_verification_email,
+    send_password_reset_email,
+    _translate_password_errors,
+)
 from .serializers import (
     UserRegistrationSerializer,
     UserSerializer,
@@ -17,11 +23,6 @@ from .serializers import (
     AdminUserUpdateSerializer,
 )
 from .models import GlobalSettings
-from .utils import (
-    check_and_record_rate_limit,
-    send_verification_email,
-    send_password_reset_email,
-)
 
 User = get_user_model()
 
@@ -165,7 +166,7 @@ class PasswordResetConfirmView(views.APIView):
             validate_password(new_password, user=user)
         except ValidationError as e:
             return Response(
-                {"error": " ".join(e.messages)},
+                {"error": _translate_password_errors(e)},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { login } from '../api/auth';
 import { useNavigate, Link } from 'react-router-dom';
-import { LockClosedIcon } from '@heroicons/react/24/solid';
+import { LockClosedIcon, ArrowPathIcon } from '@heroicons/react/24/solid';
 
 export default function LoginPage() {
     const [email, setEmail] = useState('');
@@ -46,6 +46,12 @@ export default function LoginPage() {
                         </Link>
                     </p>
                 </div>
+                {mutation.isPending && (
+                    <div className="flex items-center justify-center gap-2 bg-blue-50 rounded-md p-4">
+                        <ArrowPathIcon className="h-5 w-5 text-blue-600 animate-spin" />
+                        <p className="text-sm font-medium text-blue-700">Prihlasovanie v priebehu...</p>
+                    </div>
+                )}
                 <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
                     {errorMsg && (
                         <div className="rounded-md bg-red-50 p-4">
@@ -109,8 +115,9 @@ export default function LoginPage() {
                         <button
                             type="submit"
                             disabled={mutation.isPending}
-                            className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200"
+                            className="group relative w-full flex justify-center items-center gap-2 py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 disabled:opacity-70 disabled:cursor-not-allowed"
                         >
+                            {mutation.isPending && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
                             {mutation.isPending ? 'Prihlasovanie...' : 'Prihlásiť sa'}
                         </button>
                     </div>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -32,9 +32,9 @@ export default function RegisterPage() {
 
     const emailValid = EMAIL_REGEX.test(formData.email);
     const hasMinLength = formData.password.length >= 8;
-    const hasNumber = !/^\d+$/.test(formData.password);
+    const notEntirelyNumeric = formData.password.length > 0 && !/^\d+$/.test(formData.password);
     const passwordsMatch = formData.password === formData.confirmPassword && formData.confirmPassword !== '';
-    const canSubmit = emailValid && hasMinLength && hasNumber && passwordsMatch;
+    const canSubmit = emailValid && hasMinLength && notEntirelyNumeric && passwordsMatch;
 
     const mutation = useMutation({
         mutationFn: () => register({
@@ -171,7 +171,7 @@ export default function RegisterPage() {
                             {(passwordTouched || formData.password) && (
                                 <ul className="mt-3 space-y-1 pl-1">
                                     <Requirement met={hasMinLength} label="Aspoň 8 znakov" />
-                                    <Requirement met={hasNumber} label="Nesmie obsahovať iba číslice" />
+                                    <Requirement met={notEntirelyNumeric} label="Nesmie obsahovať iba číslice" />
                                 </ul>
                             )}
                         </div>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -32,7 +32,7 @@ export default function RegisterPage() {
 
     const emailValid = EMAIL_REGEX.test(formData.email);
     const hasMinLength = formData.password.length >= 8;
-    const hasNumber = /\d/.test(formData.password);
+    const hasNumber = !/^\d+$/.test(formData.password);
     const passwordsMatch = formData.password === formData.confirmPassword && formData.confirmPassword !== '';
     const canSubmit = emailValid && hasMinLength && hasNumber && passwordsMatch;
 
@@ -171,7 +171,7 @@ export default function RegisterPage() {
                             {(passwordTouched || formData.password) && (
                                 <ul className="mt-3 space-y-1 pl-1">
                                     <Requirement met={hasMinLength} label="Aspoň 8 znakov" />
-                                    <Requirement met={hasNumber} label="Aspoň jedna číslica" />
+                                    <Requirement met={hasNumber} label="Nesmie obsahovať iba číslice" />
                                 </ul>
                             )}
                         </div>

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -27,7 +27,7 @@ export default function ResetPasswordPage() {
     const [success, setSuccess] = useState(false);
 
     const hasMinLength = newPassword.length >= 8;
-    const hasNumber = /\d/.test(newPassword);
+    const hasNumber = !/^\d+$/.test(newPassword);
     const passwordsMatch = newPassword === confirmPassword && confirmPassword !== '';
     const canSubmit = hasMinLength && hasNumber && passwordsMatch;
 
@@ -127,7 +127,7 @@ export default function ResetPasswordPage() {
                                 {(passwordTouched || newPassword) && (
                                     <ul className="mt-3 space-y-1 pl-1">
                                         <Requirement met={hasMinLength} label="Aspoň 8 znakov" />
-                                        <Requirement met={hasNumber} label="Aspoň jedna číslica" />
+                                        <Requirement met={hasNumber} label="Nesmie obsahovať iba číslice" />
                                     </ul>
                                 )}
                             </div>

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -5,12 +5,31 @@ import { useParams, Link } from 'react-router-dom';
 import { LockClosedIcon, CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import { confirmPasswordReset } from '../api/auth';
 
+function Requirement({ met, label }: { met: boolean; label: string }) {
+    return (
+        <li className="flex items-center gap-2 text-sm">
+            {met ? (
+                <CheckCircleIcon className="h-4 w-4 text-green-500 shrink-0" />
+            ) : (
+                <XCircleIcon className="h-4 w-4 text-gray-300 shrink-0" />
+            )}
+            <span className={met ? 'text-green-700' : 'text-gray-500'}>{label}</span>
+        </li>
+    );
+}
+
 export default function ResetPasswordPage() {
     const { uid, token } = useParams();
     const [newPassword, setNewPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
+    const [passwordTouched, setPasswordTouched] = useState(false);
     const [errorMsg, setErrorMsg] = useState('');
     const [success, setSuccess] = useState(false);
+
+    const hasMinLength = newPassword.length >= 8;
+    const hasNumber = /\d/.test(newPassword);
+    const passwordsMatch = newPassword === confirmPassword && confirmPassword !== '';
+    const canSubmit = hasMinLength && hasNumber && passwordsMatch;
 
     const mutation = useMutation({
         mutationFn: () => confirmPasswordReset(uid!, token!, newPassword),
@@ -34,12 +53,8 @@ export default function ResetPasswordPage() {
             setErrorMsg('Neplatný odkaz. Chýbajú parametre.');
             return;
         }
-        if (newPassword.length < 8) {
-            setErrorMsg('Heslo musí mať aspoň 8 znakov.');
-            return;
-        }
-        if (newPassword !== confirmPassword) {
-            setErrorMsg('Heslá sa nezhodujú.');
+        if (!canSubmit) {
+            setErrorMsg('Prosím, vyplňte všetky požiadavky na heslo.');
             return;
         }
 
@@ -103,12 +118,18 @@ export default function ResetPasswordPage() {
                                     name="new_password"
                                     type="password"
                                     required
-                                    minLength={8}
                                     className="mt-1 appearance-none block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                                    placeholder="Minimálne 8 znakov"
+                                    placeholder="Minimálne 8 znakov s číslicou"
                                     value={newPassword}
                                     onChange={(e) => setNewPassword(e.target.value)}
+                                    onBlur={() => setPasswordTouched(true)}
                                 />
+                                {(passwordTouched || newPassword) && (
+                                    <ul className="mt-3 space-y-1 pl-1">
+                                        <Requirement met={hasMinLength} label="Aspoň 8 znakov" />
+                                        <Requirement met={hasNumber} label="Aspoň jedna číslica" />
+                                    </ul>
+                                )}
                             </div>
                             <div>
                                 <label htmlFor="confirm_password" className="block text-sm font-medium text-gray-700">
@@ -124,14 +145,19 @@ export default function ResetPasswordPage() {
                                     value={confirmPassword}
                                     onChange={(e) => setConfirmPassword(e.target.value)}
                                 />
+                                {confirmPassword && (
+                                    <ul className="mt-3 space-y-1 pl-1">
+                                        <Requirement met={passwordsMatch} label="Heslá sa zhodujú" />
+                                    </ul>
+                                )}
                             </div>
                         </div>
 
                         <div>
                             <button
                                 type="submit"
-                                disabled={mutation.isPending}
-                                className="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 disabled:opacity-50"
+                                disabled={!canSubmit || mutation.isPending}
+                                className="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 {mutation.isPending ? 'Ukladám...' : 'Nastaviť nové heslo'}
                             </button>

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -27,9 +27,9 @@ export default function ResetPasswordPage() {
     const [success, setSuccess] = useState(false);
 
     const hasMinLength = newPassword.length >= 8;
-    const hasNumber = !/^\d+$/.test(newPassword);
+    const notEntirelyNumeric = newPassword.length > 0 && !/^\d+$/.test(newPassword);
     const passwordsMatch = newPassword === confirmPassword && confirmPassword !== '';
-    const canSubmit = hasMinLength && hasNumber && passwordsMatch;
+    const canSubmit = hasMinLength && notEntirelyNumeric && passwordsMatch;
 
     const mutation = useMutation({
         mutationFn: () => confirmPasswordReset(uid!, token!, newPassword),
@@ -118,8 +118,9 @@ export default function ResetPasswordPage() {
                                     name="new_password"
                                     type="password"
                                     required
+                                    minLength={8}
                                     className="mt-1 appearance-none block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                                    placeholder="Minimálne 8 znakov s číslicou"
+                                    placeholder="Aspoň 8 znakov, nesmie byť iba číslice"
                                     value={newPassword}
                                     onChange={(e) => setNewPassword(e.target.value)}
                                     onBlur={() => setPasswordTouched(true)}
@@ -127,7 +128,7 @@ export default function ResetPasswordPage() {
                                 {(passwordTouched || newPassword) && (
                                     <ul className="mt-3 space-y-1 pl-1">
                                         <Requirement met={hasMinLength} label="Aspoň 8 znakov" />
-                                        <Requirement met={hasNumber} label="Nesmie obsahovať iba číslice" />
+                                        <Requirement met={notEntirelyNumeric} label="Nesmie obsahovať iba číslice" />
                                     </ul>
                                 )}
                             </div>


### PR DESCRIPTION
Frontend: add inline password requirement UI + submit gating on reset password, and add login loading indicators.
Backend: enforce Django password validators on registration + password reset confirmation, and send HTML versions of verification/password-reset/order emails.
Backend: change the seeding command to only delete products not referenced by orders.