### PR TITLE
feat: refactor order processing by introducing service layer

### DIFF
--- a/backend/orders/serializers.py
+++ b/backend/orders/serializers.py
@@ -2,11 +2,7 @@ import logging
 
 from rest_framework import serializers
 from .models import Order, OrderItem
-from products.models import Product
-from decimal import Decimal
-import uuid
-from django.db import transaction
-from services.email import OrderEmailService
+from .services import OrderService
 
 logger = logging.getLogger(__name__)
 
@@ -64,90 +60,21 @@ class OrderCreateSerializer(serializers.ModelSerializer):
         return value
 
     def create(self, validated_data):
-        items_data = validated_data.pop("items")
+        """
+        Create a new order using the OrderService.
 
-        # Use atomic transaction to ensure all-or-nothing behavior
-        with transaction.atomic():
-            # Generate unique order number
-            order_number = str(uuid.uuid4())[:8].upper()
+        This serializer now delegates all business logic to the service layer,
+        focusing solely on serialization and validation.
+        """
+        # Get user from context if authenticated
+        request = self.context.get("request")
+        user = request.user if request and request.user.is_authenticated else None
 
-            # Calculate total and validate products
-            total_price = Decimal("0.00")
-            items_to_create = []
-            products_to_update = []
+        # Delegate to service layer
+        service = OrderService(user=user)
+        order = service.create_order(validated_data)
 
-            for item_data in items_data:
-                try:
-                    # Use select_for_update to lock the row and prevent race conditions
-                    product = Product.objects.select_for_update().get(
-                        id=item_data["product_id"]
-                    )
-                except Product.DoesNotExist:
-                    raise serializers.ValidationError(
-                        f"Product with id {item_data['product_id']} does not exist."
-                    )
-
-                quantity = item_data["quantity"]
-
-                # Validate stock
-                if product.stock_quantity < quantity:
-                    raise serializers.ValidationError(
-                        f"Not enough stock for product '{product.name}'. "
-                        f"Available: {product.stock_quantity}, Requested: {quantity}"
-                    )
-
-                # Use product's current price as snapshot
-                price_snapshot = product.price
-                subtotal = price_snapshot * quantity
-                total_price += subtotal
-
-                # Deduct stock
-                product.stock_quantity -= quantity
-                products_to_update.append(product)
-
-                items_to_create.append(
-                    {
-                        "product": product,
-                        "quantity": quantity,
-                        "price_snapshot": price_snapshot,
-                    }
-                )
-
-            # Update all product stocks
-            for product in products_to_update:
-                product.save()
-
-            # Get user if authenticated
-            request = self.context.get("request")
-            user = request.user if request and request.user.is_authenticated else None
-
-            # Set status based on payment method
-            payment_method = validated_data.get("payment_method", "bank_transfer")
-            if payment_method == "bank_transfer":
-                status = "awaiting_payment"
-            else:
-                status = "new"
-
-            # Create order
-            order = Order.objects.create(
-                user=user,
-                order_number=order_number,
-                status=status,
-                total_price=total_price,
-                **validated_data,
-            )
-
-            # Create order items
-            for item_data in items_to_create:
-                OrderItem.objects.create(order=order, **item_data)
-
-            # Send confirmation emails after the transaction commits so DB locks
-            # are released before the (potentially slow) PDF generation + SMTP calls.
-            transaction.on_commit(
-                lambda: OrderEmailService(order).send_confirmation_emails()
-            )
-
-            return order
+        return order
 
 
 class OrderSerializer(serializers.ModelSerializer):

--- a/backend/orders/services/__init__.py
+++ b/backend/orders/services/__init__.py
@@ -1,0 +1,16 @@
+"""
+Order services module.
+
+This module contains business logic for order processing,
+separated from serialization concerns.
+"""
+
+from .order_service import OrderService
+from .stock_service import StockService
+from .pricing_service import PricingService
+
+__all__ = [
+    "OrderService",
+    "StockService",
+    "PricingService",
+]

--- a/backend/orders/services/order_service.py
+++ b/backend/orders/services/order_service.py
@@ -100,8 +100,9 @@ class OrderService:
             transaction.on_commit(lambda: self._send_order_notifications(order))
 
             logger.info(
-                f"Order created successfully: {order.order_number} - "
-                f"Total: {order.total_price}"
+                "Order created successfully: %s - Total: %s",
+                order.order_number,
+                order.total_price,
             )
 
             return order
@@ -156,7 +157,7 @@ class OrderService:
             **validated_data,
         )
 
-        logger.info(f"Order instance created: {order.order_number}")
+        logger.info("Order instance created: %s", order.order_number)
         return order
 
     def _create_order_items(
@@ -173,7 +174,7 @@ class OrderService:
             OrderItem.objects.create(order=order, **item_data)
 
         logger.info(
-            f"Created {len(prepared_items)} order items for {order.order_number}"
+            "Created %s order items for %s", len(prepared_items), order.order_number
         )
 
     def _send_order_notifications(self, order: Order) -> None:
@@ -188,9 +189,9 @@ class OrderService:
         """
         try:
             OrderEmailService(order).send_confirmation_emails()
-            logger.info(f"Email notifications sent for order {order.order_number}")
+            logger.info("Email notifications sent for order %s", order.order_number)
         except Exception:
             # Log the error with full traceback but don't raise - order is already created
             logger.exception(
-                f"Failed to send email notifications for order {order.order_number}"
+                "Failed to send email notifications for order %s", order.order_number
             )

--- a/backend/orders/services/order_service.py
+++ b/backend/orders/services/order_service.py
@@ -6,6 +6,7 @@ Contains the core business logic for order processing.
 
 import logging
 import uuid
+from decimal import Decimal
 from typing import Dict, Any, Optional, List
 from django.db import transaction
 from django.contrib.auth import get_user_model
@@ -132,7 +133,7 @@ class OrderService:
         self,
         validated_data: Dict[str, Any],
         order_number: str,
-        total_price: Any,
+        total_price: Decimal,
         status: str,
     ) -> Order:
         """
@@ -188,8 +189,8 @@ class OrderService:
         try:
             OrderEmailService(order).send_confirmation_emails()
             logger.info(f"Email notifications sent for order {order.order_number}")
-        except Exception as e:
-            # Log the error but don't raise - order is already created
-            logger.error(
-                f"Failed to send email notifications for order {order.order_number}: {str(e)}"
+        except Exception:
+            # Log the error with full traceback but don't raise - order is already created
+            logger.exception(
+                f"Failed to send email notifications for order {order.order_number}"
             )

--- a/backend/orders/services/order_service.py
+++ b/backend/orders/services/order_service.py
@@ -1,0 +1,195 @@
+"""
+Order creation and management service.
+
+Contains the core business logic for order processing.
+"""
+
+import logging
+import uuid
+from typing import Dict, Any, Optional, List
+from django.db import transaction
+from django.contrib.auth import get_user_model
+
+from orders.models import Order, OrderItem
+from services.email import OrderEmailService
+from .stock_service import StockService
+from .pricing_service import PricingService
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+class OrderService:
+    """
+    Service for managing order creation and lifecycle.
+
+    This service orchestrates the entire order creation process:
+    1. Stock validation and reservation
+    2. Price calculation
+    3. Order instance creation
+    4. Order items creation
+    5. Email notifications
+
+    All operations are wrapped in a database transaction for data consistency.
+    """
+
+    def __init__(self, user: Optional[User] = None):
+        """
+        Initialize the order service.
+
+        Args:
+            user: The authenticated user creating the order (optional)
+        """
+        self.user = user
+        self.stock_service = StockService()
+        self.pricing_service = PricingService()
+
+    def create_order(self, validated_data: Dict[str, Any]) -> Order:
+        """
+        Create a new order with all associated items.
+
+        This method:
+        1. Extracts items data from validated_data
+        2. Wraps everything in a database transaction
+        3. Validates and reserves stock
+        4. Calculates total price
+        5. Creates order and order items
+        6. Sends confirmation emails (after transaction commits)
+
+        Args:
+            validated_data: Validated order data including items
+
+        Returns:
+            Created Order instance
+
+        Raises:
+            ValidationError: If stock validation fails or products don't exist
+        """
+        items_data = validated_data.pop("items")
+
+        with transaction.atomic():
+            # Validate stock and prepare items (locks products)
+            prepared_items = self.stock_service.validate_and_reserve_stock(items_data)
+
+            # Calculate total price
+            total_price = self.pricing_service.calculate_order_total(prepared_items)
+
+            # Generate unique order number
+            order_number = self._generate_order_number()
+
+            # Determine order status based on payment method
+            status = self._determine_initial_status(
+                validated_data.get("payment_method", "bank_transfer")
+            )
+
+            # Create the order instance
+            order = self._create_order_instance(
+                validated_data=validated_data,
+                order_number=order_number,
+                total_price=total_price,
+                status=status,
+            )
+
+            # Create order items
+            self._create_order_items(order, prepared_items)
+
+            # Schedule email notifications after transaction commits
+            # This ensures DB locks are released before potentially slow SMTP calls
+            transaction.on_commit(lambda: self._send_order_notifications(order))
+
+            logger.info(
+                f"Order created successfully: {order.order_number} - "
+                f"Total: {order.total_price}"
+            )
+
+            return order
+
+    def _generate_order_number(self) -> str:
+        """
+        Generate a unique order number.
+
+        Returns:
+            8-character uppercase alphanumeric order number
+        """
+        return str(uuid.uuid4())[:8].upper()
+
+    def _determine_initial_status(self, payment_method: str) -> str:
+        """
+        Determine the initial order status based on payment method.
+
+        Args:
+            payment_method: Payment method chosen by customer
+
+        Returns:
+            Initial order status
+        """
+        if payment_method == "bank_transfer":
+            return "awaiting_payment"
+        return "new"
+
+    def _create_order_instance(
+        self,
+        validated_data: Dict[str, Any],
+        order_number: str,
+        total_price: Any,
+        status: str,
+    ) -> Order:
+        """
+        Create the Order instance.
+
+        Args:
+            validated_data: Validated order data
+            order_number: Generated order number
+            total_price: Calculated total price
+            status: Initial order status
+
+        Returns:
+            Created Order instance
+        """
+        order = Order.objects.create(
+            user=self.user,
+            order_number=order_number,
+            status=status,
+            total_price=total_price,
+            **validated_data,
+        )
+
+        logger.info(f"Order instance created: {order.order_number}")
+        return order
+
+    def _create_order_items(
+        self, order: Order, prepared_items: List[Dict[str, Any]]
+    ) -> None:
+        """
+        Create OrderItem instances for the order.
+
+        Args:
+            order: The order to attach items to
+            prepared_items: List of prepared item data with product, quantity, price_snapshot
+        """
+        for item_data in prepared_items:
+            OrderItem.objects.create(order=order, **item_data)
+
+        logger.info(
+            f"Created {len(prepared_items)} order items for {order.order_number}"
+        )
+
+    def _send_order_notifications(self, order: Order) -> None:
+        """
+        Send email notifications for the order.
+
+        This is called after the transaction commits to avoid holding
+        database locks during potentially slow email operations.
+
+        Args:
+            order: The order to send notifications for
+        """
+        try:
+            OrderEmailService(order).send_confirmation_emails()
+            logger.info(f"Email notifications sent for order {order.order_number}")
+        except Exception as e:
+            # Log the error but don't raise - order is already created
+            logger.error(
+                f"Failed to send email notifications for order {order.order_number}: {str(e)}"
+            )

--- a/backend/orders/services/pricing_service.py
+++ b/backend/orders/services/pricing_service.py
@@ -1,0 +1,63 @@
+"""
+Pricing calculation service.
+
+Handles all pricing-related operations for orders.
+"""
+
+import logging
+from typing import List, Dict, Any
+from decimal import Decimal
+
+logger = logging.getLogger(__name__)
+
+
+class PricingService:
+    """
+    Service for calculating order prices.
+
+    Responsibilities:
+    - Calculate item subtotals
+    - Calculate order total
+    - Handle price snapshots
+    """
+
+    @staticmethod
+    def calculate_order_total(prepared_items: List[Dict[str, Any]]) -> Decimal:
+        """
+        Calculate the total price for an order.
+
+        Args:
+            prepared_items: List of dicts with 'price_snapshot' and 'quantity' keys
+
+        Returns:
+            Total price as Decimal
+        """
+        total_price = Decimal("0.00")
+
+        for item in prepared_items:
+            price_snapshot = item["price_snapshot"]
+            quantity = item["quantity"]
+            subtotal = price_snapshot * quantity
+            total_price += subtotal
+
+            logger.debug(
+                f"Item pricing: {item.get('product', 'Unknown')} - "
+                f"{quantity} × {price_snapshot} = {subtotal}"
+            )
+
+        logger.info(f"Order total calculated: {total_price}")
+        return total_price
+
+    @staticmethod
+    def calculate_item_subtotal(price: Decimal, quantity: int) -> Decimal:
+        """
+        Calculate subtotal for a single item.
+
+        Args:
+            price: Unit price
+            quantity: Quantity ordered
+
+        Returns:
+            Subtotal as Decimal
+        """
+        return price * quantity

--- a/backend/orders/services/pricing_service.py
+++ b/backend/orders/services/pricing_service.py
@@ -41,11 +41,14 @@ class PricingService:
             total_price += subtotal
 
             logger.debug(
-                f"Item pricing: {item.get('product', 'Unknown')} - "
-                f"{quantity} × {price_snapshot} = {subtotal}"
+                "Item pricing: %s - %s × %s = %s",
+                item.get("product", "Unknown"),
+                quantity,
+                price_snapshot,
+                subtotal,
             )
 
-        logger.info(f"Order total calculated: {total_price}")
+        logger.info("Order total calculated: %s", total_price)
         return total_price
 
     @staticmethod

--- a/backend/orders/services/stock_service.py
+++ b/backend/orders/services/stock_service.py
@@ -1,0 +1,109 @@
+"""
+Stock management service.
+
+Handles all stock-related operations for order processing.
+"""
+
+import logging
+from typing import List, Dict, Any
+from django.db import transaction
+from rest_framework import serializers
+from products.models import Product
+
+logger = logging.getLogger(__name__)
+
+
+class StockService:
+    """
+    Service for managing product stock operations.
+
+    Responsibilities:
+    - Validate stock availability
+    - Deduct stock quantities
+    - Lock products during transactions
+    """
+
+    @staticmethod
+    def validate_and_reserve_stock(
+        items_data: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """
+        Validate stock availability and prepare items for order creation.
+
+        This method:
+        1. Locks products using select_for_update() to prevent race conditions
+        2. Validates that sufficient stock is available
+        3. Deducts stock quantities
+        4. Returns prepared item data with product instances and price snapshots
+
+        Args:
+            items_data: List of dicts with 'product_id' and 'quantity' keys
+
+        Returns:
+            List of dicts with 'product', 'quantity', and 'price_snapshot' keys
+
+        Raises:
+            serializers.ValidationError: If product not found or insufficient stock
+        """
+        products_to_update = []
+        prepared_items = []
+
+        for item_data in items_data:
+            product_id = item_data["product_id"]
+            quantity = item_data["quantity"]
+
+            # Lock the product row to prevent race conditions
+            try:
+                product = Product.objects.select_for_update().get(id=product_id)
+            except Product.DoesNotExist:
+                raise serializers.ValidationError(
+                    f"Product with id {product_id} does not exist."
+                )
+
+            # Validate stock availability
+            if product.stock_quantity < quantity:
+                raise serializers.ValidationError(
+                    f"Not enough stock for product '{product.name}'. "
+                    f"Available: {product.stock_quantity}, Requested: {quantity}"
+                )
+
+            # Deduct stock
+            product.stock_quantity -= quantity
+            products_to_update.append(product)
+
+            # Prepare item data with product instance and price snapshot
+            prepared_items.append(
+                {
+                    "product": product,
+                    "quantity": quantity,
+                    "price_snapshot": product.price,
+                }
+            )
+
+        # Save all updated products
+        for product in products_to_update:
+            product.save()
+            logger.info(
+                f"Stock deducted: {product.name} - "
+                f"New quantity: {product.stock_quantity}"
+            )
+
+        return prepared_items
+
+    @staticmethod
+    def restore_stock(items: List[Dict[str, Any]]) -> None:
+        """
+        Restore stock quantities (e.g., in case of order cancellation).
+
+        Args:
+            items: List of dicts with 'product' and 'quantity' keys
+        """
+        with transaction.atomic():
+            for item in items:
+                product = Product.objects.select_for_update().get(id=item["product"].id)
+                product.stock_quantity += item["quantity"]
+                product.save()
+                logger.info(
+                    f"Stock restored: {product.name} - "
+                    f"New quantity: {product.stock_quantity}"
+                )

--- a/backend/orders/services/stock_service.py
+++ b/backend/orders/services/stock_service.py
@@ -31,10 +31,14 @@ class StockService:
         Validate stock availability and prepare items for order creation.
 
         This method:
-        1. Locks products using select_for_update() to prevent race conditions
-        2. Validates that sufficient stock is available
-        3. Deducts stock quantities
-        4. Returns prepared item data with product instances and price snapshots
+        1. Aggregates quantities by product_id to handle duplicates
+        2. Locks products using select_for_update() to prevent race conditions
+        3. Validates that sufficient stock is available
+        4. Deducts stock quantities
+        5. Returns prepared item data with product instances and price snapshots
+
+        Note: Wraps operations in transaction.atomic() to ensure select_for_update()
+        works correctly. Nested transactions are safe in Django.
 
         Args:
             items_data: List of dicts with 'product_id' and 'quantity' keys
@@ -45,50 +49,57 @@ class StockService:
         Raises:
             serializers.ValidationError: If product not found or insufficient stock
         """
-        products_to_update = []
-        prepared_items = []
-
-        for item_data in items_data:
-            product_id = item_data["product_id"]
-            quantity = item_data["quantity"]
-
-            # Lock the product row to prevent race conditions
-            try:
-                product = Product.objects.select_for_update().get(id=product_id)
-            except Product.DoesNotExist:
-                raise serializers.ValidationError(
-                    f"Product with id {product_id} does not exist."
+        with transaction.atomic():
+            # Aggregate quantities by product_id to handle duplicate products
+            product_quantities = {}
+            for item_data in items_data:
+                product_id = item_data["product_id"]
+                quantity = item_data["quantity"]
+                product_quantities[product_id] = (
+                    product_quantities.get(product_id, 0) + quantity
                 )
 
-            # Validate stock availability
-            if product.stock_quantity < quantity:
-                raise serializers.ValidationError(
-                    f"Not enough stock for product '{product.name}'. "
-                    f"Available: {product.stock_quantity}, Requested: {quantity}"
+            products_to_update = []
+            prepared_items = []
+
+            for product_id, total_quantity in product_quantities.items():
+                # Lock the product row to prevent race conditions
+                try:
+                    product = Product.objects.select_for_update().get(id=product_id)
+                except Product.DoesNotExist:
+                    raise serializers.ValidationError(
+                        f"Product with id {product_id} does not exist."
+                    )
+
+                # Validate stock availability
+                if product.stock_quantity < total_quantity:
+                    raise serializers.ValidationError(
+                        f"Not enough stock for product '{product.name}'. "
+                        f"Available: {product.stock_quantity}, Requested: {total_quantity}"
+                    )
+
+                # Deduct stock
+                product.stock_quantity -= total_quantity
+                products_to_update.append(product)
+
+                # Prepare item data with product instance and price snapshot
+                prepared_items.append(
+                    {
+                        "product": product,
+                        "quantity": total_quantity,
+                        "price_snapshot": product.price,
+                    }
                 )
 
-            # Deduct stock
-            product.stock_quantity -= quantity
-            products_to_update.append(product)
+            # Save all updated products
+            for product in products_to_update:
+                product.save()
+                logger.info(
+                    f"Stock deducted: {product.name} - "
+                    f"New quantity: {product.stock_quantity}"
+                )
 
-            # Prepare item data with product instance and price snapshot
-            prepared_items.append(
-                {
-                    "product": product,
-                    "quantity": quantity,
-                    "price_snapshot": product.price,
-                }
-            )
-
-        # Save all updated products
-        for product in products_to_update:
-            product.save()
-            logger.info(
-                f"Stock deducted: {product.name} - "
-                f"New quantity: {product.stock_quantity}"
-            )
-
-        return prepared_items
+            return prepared_items
 
     @staticmethod
     def restore_stock(items: List[Dict[str, Any]]) -> None:

--- a/backend/orders/services/stock_service.py
+++ b/backend/orders/services/stock_service.py
@@ -31,75 +31,95 @@ class StockService:
         Validate stock availability and prepare items for order creation.
 
         This method:
-        1. Aggregates quantities by product_id to handle duplicates
+        1. Aggregates quantities by product_id to validate against total (prevents overselling)
         2. Locks products using select_for_update() to prevent race conditions
-        3. Validates that sufficient stock is available
-        4. Deducts stock quantities
-        5. Returns prepared item data with product instances and price snapshots
+        3. Validates that sufficient stock is available for the total quantity
+        4. Deducts stock quantities once per unique product
+        5. Returns individual prepared items (maintains one OrderItem per input item)
 
-        Note: Wraps operations in transaction.atomic() to ensure select_for_update()
-        works correctly. Nested transactions are safe in Django.
+        Note: Only wraps in transaction.atomic() if not already in an atomic block,
+        to avoid unnecessary savepoints.
 
         Args:
             items_data: List of dicts with 'product_id' and 'quantity' keys
 
         Returns:
             List of dicts with 'product', 'quantity', and 'price_snapshot' keys
+            (one entry per input item, preserving order and individual quantities)
 
         Raises:
             serializers.ValidationError: If product not found or insufficient stock
         """
-        with transaction.atomic():
-            # Aggregate quantities by product_id to handle duplicate products
-            product_quantities = {}
-            for item_data in items_data:
-                product_id = item_data["product_id"]
-                quantity = item_data["quantity"]
-                product_quantities[product_id] = (
-                    product_quantities.get(product_id, 0) + quantity
+        # Only create transaction if not already in one (avoid unnecessary savepoint)
+        if not transaction.get_connection().in_atomic_block:
+            with transaction.atomic():
+                return StockService._validate_and_reserve_stock_impl(items_data)
+        else:
+            return StockService._validate_and_reserve_stock_impl(items_data)
+
+    @staticmethod
+    def _validate_and_reserve_stock_impl(
+        items_data: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Internal implementation of validate_and_reserve_stock."""
+        # First pass: aggregate quantities by product_id for validation
+        product_quantities = {}
+        for item_data in items_data:
+            product_id = item_data["product_id"]
+            quantity = item_data["quantity"]
+            product_quantities[product_id] = (
+                product_quantities.get(product_id, 0) + quantity
+            )
+
+        # Second pass: lock products, validate, and deduct stock
+        locked_products = {}  # Cache locked products by id
+        for product_id, total_quantity in product_quantities.items():
+            # Lock the product row to prevent race conditions
+            try:
+                product = Product.objects.select_for_update().get(id=product_id)
+            except Product.DoesNotExist:
+                raise serializers.ValidationError(
+                    f"Product with id {product_id} does not exist."
                 )
 
-            products_to_update = []
-            prepared_items = []
-
-            for product_id, total_quantity in product_quantities.items():
-                # Lock the product row to prevent race conditions
-                try:
-                    product = Product.objects.select_for_update().get(id=product_id)
-                except Product.DoesNotExist:
-                    raise serializers.ValidationError(
-                        f"Product with id {product_id} does not exist."
-                    )
-
-                # Validate stock availability
-                if product.stock_quantity < total_quantity:
-                    raise serializers.ValidationError(
-                        f"Not enough stock for product '{product.name}'. "
-                        f"Available: {product.stock_quantity}, Requested: {total_quantity}"
-                    )
-
-                # Deduct stock
-                product.stock_quantity -= total_quantity
-                products_to_update.append(product)
-
-                # Prepare item data with product instance and price snapshot
-                prepared_items.append(
-                    {
-                        "product": product,
-                        "quantity": total_quantity,
-                        "price_snapshot": product.price,
-                    }
+            # Validate stock availability against total quantity
+            if product.stock_quantity < total_quantity:
+                raise serializers.ValidationError(
+                    f"Not enough stock for product '{product.name}'. "
+                    f"Available: {product.stock_quantity}, Requested: {total_quantity}"
                 )
 
-            # Save all updated products
-            for product in products_to_update:
-                product.save()
-                logger.info(
-                    f"Stock deducted: {product.name} - "
-                    f"New quantity: {product.stock_quantity}"
-                )
+            # Deduct total stock for this product
+            product.stock_quantity -= total_quantity
+            product.save()
+            locked_products[product_id] = product
 
-            return prepared_items
+            logger.debug(
+                "Stock deducted: %s - New quantity: %s",
+                product.name,
+                product.stock_quantity,
+            )
+
+        # Third pass: prepare individual items (maintains original structure)
+        # This ensures one OrderItem per input item, not per unique product
+        prepared_items = []
+        for item_data in items_data:
+            product_id = item_data["product_id"]
+            product = locked_products[product_id]
+            prepared_items.append(
+                {
+                    "product": product,
+                    "quantity": item_data["quantity"],
+                    "price_snapshot": product.price,
+                }
+            )
+
+        logger.info(
+            "Stock reserved for %s items across %s unique products",
+            len(prepared_items),
+            len(locked_products),
+        )
+        return prepared_items
 
     @staticmethod
     def restore_stock(items: List[Dict[str, Any]]) -> None:
@@ -115,6 +135,7 @@ class StockService:
                 product.stock_quantity += item["quantity"]
                 product.save()
                 logger.info(
-                    f"Stock restored: {product.name} - "
-                    f"New quantity: {product.stock_quantity}"
+                    "Stock restored: %s - New quantity: %s",
+                    product.name,
+                    product.stock_quantity,
                 )

--- a/backend/tests/orders/test_services.py
+++ b/backend/tests/orders/test_services.py
@@ -101,22 +101,71 @@ class TestStockService:
         assert product2.stock_quantity == 5
 
     @pytest.mark.django_db
-    def test_select_for_update_prevents_race_condition(self, product_factory):
-        """Test that select_for_update locks prevent race conditions."""
+    def test_validate_and_reserve_stock_with_transaction(self, product_factory):
+        """Test stock reservation and deduction within a database transaction."""
         product = product_factory(price=Decimal("100.00"), stock_quantity=10)
 
         items_data = [{"product_id": product.id, "quantity": 5}]
 
-        # This should acquire a lock on the product row
-        with transaction.atomic():
-            prepared_items = StockService.validate_and_reserve_stock(items_data)
+        # Perform stock validation and reservation
+        # (method now wraps itself in transaction.atomic())
+        prepared_items = StockService.validate_and_reserve_stock(items_data)
 
-            # Within this transaction, the product row is locked
-            assert len(prepared_items) == 1
+        # The service should return the expected prepared item
+        assert len(prepared_items) == 1
+        assert prepared_items[0]["product"] == product
+        assert prepared_items[0]["quantity"] == 5
 
-        # Lock is released after transaction commits
+        # After the transaction commits, stock should be reduced
         product.refresh_from_db()
         assert product.stock_quantity == 5
+
+    @pytest.mark.django_db
+    def test_validate_and_reserve_stock_handles_duplicate_products(
+        self, product_factory
+    ):
+        """Test that duplicate product_ids are aggregated correctly."""
+        product = product_factory(price=Decimal("100.00"), stock_quantity=10)
+
+        # Same product appears multiple times in the order
+        items_data = [
+            {"product_id": product.id, "quantity": 2},
+            {"product_id": product.id, "quantity": 3},
+            {"product_id": product.id, "quantity": 1},
+        ]
+
+        prepared_items = StockService.validate_and_reserve_stock(items_data)
+
+        # Should aggregate quantities: 2 + 3 + 1 = 6
+        assert len(prepared_items) == 1
+        assert prepared_items[0]["quantity"] == 6
+
+        # Stock should be deducted by total quantity
+        product.refresh_from_db()
+        assert product.stock_quantity == 4  # 10 - 6
+
+    @pytest.mark.django_db
+    def test_validate_and_reserve_stock_duplicate_insufficient_stock(
+        self, product_factory
+    ):
+        """Test that duplicate products validate against total quantity."""
+        product = product_factory(price=Decimal("100.00"), stock_quantity=10)
+
+        # Same product ordered multiple times, total exceeds stock
+        items_data = [
+            {"product_id": product.id, "quantity": 6},
+            {"product_id": product.id, "quantity": 5},  # Total: 11 > 10 available
+        ]
+
+        with pytest.raises(ValidationError) as exc_info:
+            StockService.validate_and_reserve_stock(items_data)
+
+        assert "Not enough stock" in str(exc_info.value)
+        assert "Requested: 11" in str(exc_info.value)
+
+        # Stock should not be deducted
+        product.refresh_from_db()
+        assert product.stock_quantity == 10
 
 
 class TestPricingService:

--- a/backend/tests/orders/test_services.py
+++ b/backend/tests/orders/test_services.py
@@ -1,0 +1,409 @@
+"""
+Unit tests for order services.
+
+Tests the business logic layer separated from serialization.
+"""
+
+import pytest
+from decimal import Decimal
+from django.db import transaction
+from rest_framework.serializers import ValidationError
+
+from orders.services import OrderService, StockService, PricingService
+from orders.models import Order, OrderItem
+
+
+class TestStockService:
+    """Test suite for StockService."""
+
+    @pytest.mark.django_db
+    def test_validate_and_reserve_stock_success(self, product_factory):
+        """Test successful stock validation and reservation."""
+        product1 = product_factory(price=Decimal("100.00"), stock_quantity=10)
+        product2 = product_factory(price=Decimal("50.00"), stock_quantity=5)
+
+        items_data = [
+            {"product_id": product1.id, "quantity": 2},
+            {"product_id": product2.id, "quantity": 1},
+        ]
+
+        with transaction.atomic():
+            prepared_items = StockService.validate_and_reserve_stock(items_data)
+
+        assert len(prepared_items) == 2
+        assert prepared_items[0]["product"] == product1
+        assert prepared_items[0]["quantity"] == 2
+        assert prepared_items[0]["price_snapshot"] == Decimal("100.00")
+
+        # Verify stock was deducted
+        product1.refresh_from_db()
+        product2.refresh_from_db()
+        assert product1.stock_quantity == 8  # 10 - 2
+        assert product2.stock_quantity == 4  # 5 - 1
+
+    @pytest.mark.django_db
+    def test_validate_and_reserve_stock_insufficient_stock(self, product_factory):
+        """Test that ValidationError is raised when stock is insufficient."""
+        product = product_factory(price=Decimal("100.00"), stock_quantity=5)
+
+        items_data = [
+            {"product_id": product.id, "quantity": 10},  # More than available
+        ]
+
+        with pytest.raises(ValidationError) as exc_info:
+            with transaction.atomic():
+                StockService.validate_and_reserve_stock(items_data)
+
+        assert "Not enough stock" in str(exc_info.value)
+
+        # Verify stock was NOT deducted (transaction rolled back)
+        product.refresh_from_db()
+        assert product.stock_quantity == 5
+
+    @pytest.mark.django_db
+    def test_validate_and_reserve_stock_product_not_found(self):
+        """Test that ValidationError is raised when product doesn't exist."""
+        items_data = [
+            {"product_id": 99999, "quantity": 1},  # Non-existent product
+        ]
+
+        with pytest.raises(ValidationError) as exc_info:
+            with transaction.atomic():
+                StockService.validate_and_reserve_stock(items_data)
+
+        assert "does not exist" in str(exc_info.value)
+
+    @pytest.mark.django_db
+    def test_restore_stock(self, product_factory):
+        """Test stock restoration functionality."""
+        product1 = product_factory(price=Decimal("100.00"), stock_quantity=10)
+        product2 = product_factory(price=Decimal("50.00"), stock_quantity=5)
+
+        # Deduct stock first
+        product1.stock_quantity -= 2
+        product1.save()
+        product2.stock_quantity -= 3
+        product2.save()
+
+        # Prepare items for restoration
+        items = [
+            {"product": product1, "quantity": 2},
+            {"product": product2, "quantity": 3},
+        ]
+
+        # Restore stock
+        StockService.restore_stock(items)
+
+        # Verify stock was restored
+        product1.refresh_from_db()
+        product2.refresh_from_db()
+        assert product1.stock_quantity == 10
+        assert product2.stock_quantity == 5
+
+    @pytest.mark.django_db
+    def test_select_for_update_prevents_race_condition(self, product_factory):
+        """Test that select_for_update locks prevent race conditions."""
+        product = product_factory(price=Decimal("100.00"), stock_quantity=10)
+
+        items_data = [{"product_id": product.id, "quantity": 5}]
+
+        # This should acquire a lock on the product row
+        with transaction.atomic():
+            prepared_items = StockService.validate_and_reserve_stock(items_data)
+
+            # Within this transaction, the product row is locked
+            assert len(prepared_items) == 1
+
+        # Lock is released after transaction commits
+        product.refresh_from_db()
+        assert product.stock_quantity == 5
+
+
+class TestPricingService:
+    """Test suite for PricingService."""
+
+    def test_calculate_order_total(self):
+        """Test total price calculation for multiple items."""
+        prepared_items = [
+            {"price_snapshot": Decimal("100.00"), "quantity": 2},
+            {"price_snapshot": Decimal("50.00"), "quantity": 3},
+            {"price_snapshot": Decimal("25.50"), "quantity": 1},
+        ]
+
+        total = PricingService.calculate_order_total(prepared_items)
+
+        # Expected: (100 * 2) + (50 * 3) + (25.50 * 1) = 200 + 150 + 25.50 = 375.50
+        assert total == Decimal("375.50")
+
+    def test_calculate_order_total_single_item(self):
+        """Test total price calculation for a single item."""
+        prepared_items = [
+            {"price_snapshot": Decimal("99.99"), "quantity": 1},
+        ]
+
+        total = PricingService.calculate_order_total(prepared_items)
+
+        assert total == Decimal("99.99")
+
+    def test_calculate_order_total_empty_list(self):
+        """Test total price calculation for empty order."""
+        prepared_items = []
+
+        total = PricingService.calculate_order_total(prepared_items)
+
+        assert total == Decimal("0.00")
+
+    def test_calculate_item_subtotal(self):
+        """Test subtotal calculation for a single item."""
+        price = Decimal("15.99")
+        quantity = 5
+
+        subtotal = PricingService.calculate_item_subtotal(price, quantity)
+
+        assert subtotal == Decimal("79.95")
+
+    def test_calculate_item_subtotal_single_quantity(self):
+        """Test subtotal when quantity is 1."""
+        price = Decimal("42.50")
+        quantity = 1
+
+        subtotal = PricingService.calculate_item_subtotal(price, quantity)
+
+        assert subtotal == Decimal("42.50")
+
+
+class TestOrderService:
+    """Test suite for OrderService."""
+
+    @pytest.mark.django_db
+    def test_create_order_success(self, user_factory, product_factory):
+        """Test successful order creation with all components."""
+        user = user_factory()
+        product1 = product_factory(price=Decimal("100.00"), stock_quantity=10)
+        product2 = product_factory(price=Decimal("50.00"), stock_quantity=5)
+
+        order_data = {
+            "customer_name": "John Doe",
+            "email": "john@example.com",
+            "phone": "+421900123456",
+            "street": "Test Street 123",
+            "city": "Bratislava",
+            "postal_code": "811 01",
+            "is_company": False,
+            "payment_method": "bank_transfer",
+            "items": [
+                {"product_id": product1.id, "quantity": 2},
+                {"product_id": product2.id, "quantity": 1},
+            ],
+        }
+
+        service = OrderService(user=user)
+        order = service.create_order(order_data)
+
+        # Verify order was created
+        assert order.id is not None
+        assert order.user == user
+        assert order.customer_name == "John Doe"
+        assert order.email == "john@example.com"
+        assert order.total_price == Decimal("250.00")  # (100 * 2) + (50 * 1)
+        assert order.status == "awaiting_payment"  # bank_transfer status
+        assert len(order.order_number) == 8
+
+        # Verify order items were created
+        assert order.items.count() == 2
+        item1 = order.items.get(product=product1)
+        assert item1.quantity == 2
+        assert item1.price_snapshot == Decimal("100.00")
+
+        # Verify stock was deducted
+        product1.refresh_from_db()
+        product2.refresh_from_db()
+        assert product1.stock_quantity == 8
+        assert product2.stock_quantity == 4
+
+    @pytest.mark.django_db
+    def test_create_order_unauthenticated_user(self, product_factory):
+        """Test order creation without authenticated user."""
+        product = product_factory(price=Decimal("75.00"), stock_quantity=10)
+
+        order_data = {
+            "customer_name": "Guest User",
+            "email": "guest@example.com",
+            "phone": "+421900000000",
+            "street": "Guest Street 1",
+            "city": "Kosice",
+            "postal_code": "040 01",
+            "is_company": False,
+            "payment_method": "card",
+            "items": [
+                {"product_id": product.id, "quantity": 1},
+            ],
+        }
+
+        # Create service without user
+        service = OrderService(user=None)
+        order = service.create_order(order_data)
+
+        assert order.id is not None
+        assert order.user is None  # No user associated
+        assert order.total_price == Decimal("75.00")
+
+    @pytest.mark.django_db
+    def test_create_order_card_payment_status(self, user_factory, product_factory):
+        """Test that card payment creates order with 'new' status."""
+        user = user_factory()
+        product = product_factory(price=Decimal("50.00"), stock_quantity=5)
+
+        order_data = {
+            "customer_name": "Test User",
+            "email": "test@example.com",
+            "phone": "+421900111222",
+            "payment_method": "card",  # Not bank_transfer
+            "items": [
+                {"product_id": product.id, "quantity": 1},
+            ],
+        }
+
+        service = OrderService(user=user)
+        order = service.create_order(order_data)
+
+        assert order.status == "new"  # Card payment gets 'new' status
+
+    @pytest.mark.django_db
+    def test_create_order_bank_transfer_status(self, user_factory, product_factory):
+        """Test that bank transfer creates order with 'awaiting_payment' status."""
+        user = user_factory()
+        product = product_factory(price=Decimal("50.00"), stock_quantity=5)
+
+        order_data = {
+            "customer_name": "Test User",
+            "email": "test@example.com",
+            "phone": "+421900111222",
+            "payment_method": "bank_transfer",
+            "items": [
+                {"product_id": product.id, "quantity": 1},
+            ],
+        }
+
+        service = OrderService(user=user)
+        order = service.create_order(order_data)
+
+        assert order.status == "awaiting_payment"
+
+    @pytest.mark.django_db
+    def test_create_order_company_details(self, user_factory, product_factory):
+        """Test order creation with company information."""
+        user = user_factory()
+        product = product_factory(price=Decimal("100.00"), stock_quantity=10)
+
+        order_data = {
+            "customer_name": "John Doe",
+            "email": "john@company.com",
+            "phone": "+421900123456",
+            "is_company": True,
+            "company_name": "Test Company s.r.o.",
+            "ico": "12345678",
+            "dic": "1234567890",
+            "dic_dph": "SK1234567890",
+            "payment_method": "bank_transfer",
+            "items": [
+                {"product_id": product.id, "quantity": 1},
+            ],
+        }
+
+        service = OrderService(user=user)
+        order = service.create_order(order_data)
+
+        assert order.is_company is True
+        assert order.company_name == "Test Company s.r.o."
+        assert order.ico == "12345678"
+        assert order.dic == "1234567890"
+        assert order.dic_dph == "SK1234567890"
+
+    @pytest.mark.django_db
+    def test_create_order_generates_unique_order_number(
+        self, user_factory, product_factory
+    ):
+        """Test that each order gets a unique order number."""
+        user = user_factory()
+        product = product_factory(price=Decimal("50.00"), stock_quantity=20)
+
+        order_data = {
+            "customer_name": "Test User",
+            "email": "test@example.com",
+            "phone": "+421900000000",
+            "payment_method": "card",
+            "items": [
+                {"product_id": product.id, "quantity": 1},
+            ],
+        }
+
+        service = OrderService(user=user)
+
+        # Create multiple orders
+        order1 = service.create_order(order_data.copy())
+        order2 = service.create_order(order_data.copy())
+        order3 = service.create_order(order_data.copy())
+
+        # Verify all order numbers are unique
+        order_numbers = {order1.order_number, order2.order_number, order3.order_number}
+        assert len(order_numbers) == 3  # All unique
+
+    @pytest.mark.django_db
+    def test_create_order_transaction_rollback_on_error(
+        self, user_factory, product_factory
+    ):
+        """Test that transaction rolls back if order creation fails."""
+        user = user_factory()
+        product = product_factory(price=Decimal("50.00"), stock_quantity=5)
+
+        order_data = {
+            "customer_name": "Test User",
+            "email": "test@example.com",
+            "phone": "+421900000000",
+            "payment_method": "card",
+            "items": [
+                {"product_id": product.id, "quantity": 10},  # More than available
+            ],
+        }
+
+        service = OrderService(user=user)
+
+        # This should fail due to insufficient stock
+        with pytest.raises(ValidationError):
+            service.create_order(order_data)
+
+        # Verify no order was created
+        assert Order.objects.count() == 0
+        assert OrderItem.objects.count() == 0
+
+        # Verify stock was not deducted
+        product.refresh_from_db()
+        assert product.stock_quantity == 5
+
+    def test_generate_order_number_format(self):
+        """Test order number generation format."""
+        service = OrderService(user=None)
+
+        order_number = service._generate_order_number()
+
+        # Should be 8 characters, uppercase alphanumeric
+        assert len(order_number) == 8
+        assert order_number.isupper()
+        assert order_number.isalnum()
+
+    def test_determine_initial_status_bank_transfer(self):
+        """Test status determination for bank transfer."""
+        service = OrderService(user=None)
+
+        status = service._determine_initial_status("bank_transfer")
+
+        assert status == "awaiting_payment"
+
+    def test_determine_initial_status_card(self):
+        """Test status determination for card payment."""
+        service = OrderService(user=None)
+
+        status = service._determine_initial_status("card")
+
+        assert status == "new"

--- a/backend/tests/orders/test_services.py
+++ b/backend/tests/orders/test_services.py
@@ -124,7 +124,7 @@ class TestStockService:
     def test_validate_and_reserve_stock_handles_duplicate_products(
         self, product_factory
     ):
-        """Test that duplicate product_ids are aggregated correctly."""
+        """Test that duplicate product_ids are validated correctly but maintain individual items."""
         product = product_factory(price=Decimal("100.00"), stock_quantity=10)
 
         # Same product appears multiple times in the order
@@ -136,11 +136,13 @@ class TestStockService:
 
         prepared_items = StockService.validate_and_reserve_stock(items_data)
 
-        # Should aggregate quantities: 2 + 3 + 1 = 6
-        assert len(prepared_items) == 1
-        assert prepared_items[0]["quantity"] == 6
+        # Should return individual items (one OrderItem per input), not aggregated
+        assert len(prepared_items) == 3
+        assert prepared_items[0]["quantity"] == 2
+        assert prepared_items[1]["quantity"] == 3
+        assert prepared_items[2]["quantity"] == 1
 
-        # Stock should be deducted by total quantity
+        # Stock should be deducted by total quantity: 2 + 3 + 1 = 6
         product.refresh_from_db()
         assert product.stock_quantity == 4  # 10 - 6
 


### PR DESCRIPTION
Introduce OrderService, StockService, and PricingService under orders/services/ to encapsulate order creation, stock reservation/restoration, and total calculations.
Update OrderCreateSerializer.create() to delegate order creation to OrderService.
Add a new unit test suite covering the service-layer behavior.