### PR TITLE
Add product prefix storefront filters

### DIFF
--- a/backend/products/cache_utils.py
+++ b/backend/products/cache_utils.py
@@ -3,6 +3,7 @@ from django.core.cache import cache
 PRODUCT_STATS_CACHE_KEYS = (
     "category_counts",
     "compatibility_counts",
+    "product_type_counts",
 )
 
 

--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -3,6 +3,7 @@ import csv
 import pytest
 import sys
 import types
+from django.core.cache import cache
 from django.core.management import call_command
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -676,6 +677,81 @@ def test_filter_active_bypasses_default_ordering():
 
     assert response.status_code == status.HTTP_200_OK
     assert response.data["count"] == 1
+
+
+@pytest.mark.django_db
+def test_product_type_filter_uses_prefixes_and_real_compatibility_code():
+    tibase = make_product(
+        name="TiBase",
+        reference="31.312.001.01-2",
+        parameters={"compatibility_code": "0001"},
+    )
+    straight_tibase = make_product(
+        name="Straight TiBase",
+        reference="35.312.001.21-2",
+        parameters={"compatibility_code": "0001"},
+    )
+    make_product(
+        name="No compatibility number",
+        reference="31.312.999.01-2",
+        parameters={"compatibility_code": "0000"},
+    )
+    make_product(
+        name="Missing compatibility number",
+        reference="31.312.998.01-2",
+        parameters={},
+    )
+    make_product(
+        name="Multi Unit",
+        reference="42.302.001.01-2",
+        parameters={"compatibility_code": "0001"},
+    )
+
+    response = APIClient().get("/api/products/", {"product_type": "tibase"})
+    count_response = APIClient().get("/api/products/count/", {"product_type": "tibase"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert count_response.status_code == status.HTTP_200_OK
+    assert response.data["count"] == 2
+    assert count_response.data["count"] == 2
+    assert {item["id"] for item in response.data["results"]} == {
+        tibase.id,
+        straight_tibase.id,
+    }
+
+
+@pytest.mark.django_db
+def test_product_type_filter_rejects_unknown_group():
+    response = APIClient().get("/api/products/", {"product_type": "unknown"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_product_type_counts_split_adapters_and_hide_zero_groups():
+    cache.clear()
+    make_product(
+        name="Adaptor",
+        reference="50.312.001.01-2",
+        parameters={"compatibility_code": "0001"},
+    )
+    make_product(
+        name="Screwdriver",
+        reference="43.621.410.01-2",
+        parameters={"compatibility_code": "0001"},
+    )
+    make_product(
+        name="Ignored adaptor",
+        reference="50.312.999.01-2",
+        parameters={"compatibility_code": "0000"},
+    )
+
+    response = APIClient().get("/api/products/product-type-counts/")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["counts"]["adapters"] == 1
+    assert response.data["counts"]["tools"] == 1
+    assert response.data["counts"]["tibase"] == 0
 
 
 @pytest.mark.django_db

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -27,6 +27,7 @@ from .views import (
     ProductCountView,
     ProductGroupListView,
     ProductInquiryView,
+    ProductTypeCountsView,
     ProductViewSet,
 )
 
@@ -49,6 +50,11 @@ urlpatterns = [
         "category-counts/",
         CategoryCountsView.as_view(),
         name="category_counts",
+    ),
+    path(
+        "product-type-counts/",
+        ProductTypeCountsView.as_view(),
+        name="product_type_counts",
     ),
     path("count/", ProductCountView.as_view(), name="product_count"),
     path("inquiry/", ProductInquiryView.as_view(), name="product_inquiry"),

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -45,6 +45,25 @@ from .cache_utils import invalidate_product_stats_cache
 from .services import ProductService
 from .services.wildcard_sync import sync_wildcard_groups
 
+PRODUCT_TYPE_PREFIXES = {
+    "tibase": ("31", "35"),
+    "multi_unit": ("42", "48", "61", "62"),
+    "screws": ("40", "41"),
+    "scanbody": ("30", "52", "53", "54"),
+    "analogs": ("22", "23", "34"),
+    "abutments": ("21",),
+    "adapters": ("50",),
+    "tools": ("11", "33", "43"),
+}
+
+
+def _filter_real_compatibility_code(queryset):
+    return queryset.exclude(
+        models.Q(parameters__compatibility_code__isnull=True)
+        | models.Q(parameters__compatibility_code="")
+        | models.Q(parameters__compatibility_code="0000")
+    )
+
 
 def _parse_categories(request):
     # Handle both 'categories' and 'categories[]' (for array serialization compatibility)
@@ -70,6 +89,19 @@ def _apply_product_filters(queryset, request):
             qs = qs.filter(group_id=int(group_id))
         except (ValueError, TypeError):
             raise ValidationError({"group": "Must be a valid integer ID."})
+
+    product_type = request.query_params.get("product_type", "").strip()
+    if product_type:
+        prefixes = PRODUCT_TYPE_PREFIXES.get(product_type)
+        if prefixes is None:
+            raise ValidationError(
+                {"product_type": "Must be one of: " + ", ".join(PRODUCT_TYPE_PREFIXES)}
+            )
+        prefix_filter = models.Q()
+        for prefix in prefixes:
+            prefix_filter |= models.Q(reference__startswith=prefix + ".")
+        qs = qs.filter(prefix_filter)
+        qs = _filter_real_compatibility_code(qs)
 
     search = request.query_params.get("search", "").strip()
     if search:
@@ -392,6 +424,7 @@ class ProductViewSet(viewsets.ModelViewSet):
             has_filters = bool(
                 request.query_params.get("search")
                 or request.query_params.get("group")
+                or request.query_params.get("product_type")
                 or request.query_params.get("ordering")
                 or request.query_params.get("min_price")
                 or request.query_params.get("max_price")
@@ -890,6 +923,34 @@ class CompatibilityCountsView(APIView):
 
     def get(self, request, *args, **kwargs):
         return Response({"counts": get_compatibility_counts()})
+
+
+def _get_product_type_counts():
+    """Return visible product counts for storefront product-type prefix filters."""
+    cache_key = "product_type_counts"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    base_qs = _filter_real_compatibility_code(Product.objects.filter(is_visible=True))
+    counts = {}
+    for key, prefixes in PRODUCT_TYPE_PREFIXES.items():
+        prefix_filter = models.Q()
+        for prefix in prefixes:
+            prefix_filter |= models.Q(reference__startswith=prefix + ".")
+        counts[key] = base_qs.filter(prefix_filter).count()
+
+    cache.set(cache_key, counts, 3600)
+    return counts
+
+
+class ProductTypeCountsView(APIView):
+    """Public endpoint: return product counts per storefront prefix group."""
+
+    permission_classes = (permissions.AllowAny,)
+
+    def get(self, request, *args, **kwargs):
+        return Response({"counts": _get_product_type_counts()})
 
 
 class CompatibleScrewsView(APIView):

--- a/data/csv/product_prefix_audit.csv
+++ b/data/csv/product_prefix_audit.csv
@@ -1,0 +1,21 @@
+prefix,working_meaning,products_with_compatibility_num,compatibility_options_rows,distinct_compatibility_nums,blank_catalog_or_category,vat_5_candidate,audit_status
+11,Accessory / torque wrench,1,0,1,0,no,OK
+21,Dynamic abutment,117,0,42,117,no,"OK for prefix audit; catalog section blank, but compatibility nums exist"
+22,Lab analog,43,35,41,7,no,OK
+23,ScAnalog,31,29,29,1,no,OK
+30,Extraoral/lab scanbody for TiBase,8,8,8,0,maybe,OK
+31,Dynamic TiBase / Dynamic 3TiBase,724,638,153,80,yes,"OK; blank section rows should not override prefix rule"
+33,Dynamic Milling Tool,69,64,18,0,no,OK
+34,Digital analog,109,91,107,17,no,OK
+35,Straight TiBase / Straight 3TiBase,66,0,35,65,yes,"Check: TiBase by retail/name and compatibility nums, but no compatibility options rows"
+40,Straight screw / healing cap,104,60,11,43,no,Check: mixed straight screw/healing cap naming
+41,Dynamic screw,131,86,58,43,no,"OK; blank section rows should not override prefix rule"
+42,Straight Multi-Unit,168,148,51,20,yes,"OK; blank section rows should not override prefix rule"
+43,Screwdriver / screwdriver adaptor,20,14,12,4,no,OK
+48,Angulated Multi-Unit,54,54,20,0,yes,OK
+50,Scanbody adaptor,121,104,98,16,no,OK
+52,Dynamic scanbody,77,56,37,20,no,"OK; blank section rows should not override prefix rule"
+53,Scanbody / MU scanbody edge cases,7,3,6,1,maybe,OK
+54,Scanbody OP / reference scanbody,65,58,61,8,no,OK
+61,DAS MU4.0 straight Multi-Unit,53,1,14,52,yes,"Check: MU by name/compatibility nums, catalog section mostly blank"
+62,Internal Multi-Unit,21,21,10,0,yes,OK

--- a/doc/product-prefix-audit.md
+++ b/doc/product-prefix-audit.md
@@ -1,0 +1,87 @@
+# Internal product prefix audit
+
+Source snapshot: `data/csv/import_all_merged.csv`, `data/csv/compatibility_options.csv`, `data/csv/retail_prices.csv`.
+
+Scope: only products with a real `compatibility_code` are included. Rows with `compatibility_code = 0000` are ignored for this audit.
+
+Generated on: 2026-06-18.
+
+## How to read prefixes
+
+- First segment prefix means the first part of a reference, for example `31` in `31.312.210.01-2`.
+- Family prefix means the first two segments, for example `31.312`.
+- `ProductGroup.prefix` is not the same as product type. It is generated from `retail_prices.csv` wildcard rows up to the first wildcard segment, for example `54.315.xxx.21-2` creates `54.315`, while `31.xxx.xxx.01-2` creates `31`.
+- Compatibility number means `compatibility_code` from `import_all_merged.csv`, excluding `0000`.
+- Compatibility option rows are references present in `compatibility_options.csv`; this is useful for screw/options lookup, but it is not required for this prefix audit.
+
+## Prefix summary
+
+| Prefix | Working meaning | Products with compatibility num | Compatibility option rows | Distinct compatibility nums | Blank catalog/category | 5% VAT candidate | Audit status |
+|---|---:|---:|---:|---:|---:|---|---|
+| `11` | Accessory / torque wrench | 1 | 0 | 1 | 0 | No | OK |
+| `21` | Dynamic abutment | 117 | 0 | 42 | 117 | No | OK for prefix audit; catalog section blank, but compatibility nums exist |
+| `22` | Lab analog | 43 | 35 | 41 | 7 | No | OK |
+| `23` | ScAnalog | 31 | 29 | 29 | 1 | No | OK |
+| `30` | Extraoral/lab scanbody for TiBase | 8 | 8 | 8 | 0 | Maybe | OK |
+| `31` | Dynamic TiBase / Dynamic 3TiBase | 724 | 638 | 153 | 80 | Yes | OK; blank section rows should not override prefix rule |
+| `33` | Dynamic Milling Tool | 69 | 64 | 18 | 0 | No | OK |
+| `34` | Digital analog | 109 | 91 | 107 | 17 | No | OK |
+| `35` | Straight TiBase / Straight 3TiBase | 66 | 0 | 35 | 65 | Yes | Check: TiBase by retail/name and compatibility nums, but no compatibility options rows |
+| `40` | Straight screw / healing cap | 104 | 60 | 11 | 43 | No | Check: mixed straight screw/healing cap naming |
+| `41` | Dynamic screw | 131 | 86 | 58 | 43 | No | OK; blank section rows should not override prefix rule |
+| `42` | Straight Multi-Unit | 168 | 148 | 51 | 20 | Yes | OK; blank section rows should not override prefix rule |
+| `43` | Screwdriver / screwdriver adaptor | 20 | 14 | 12 | 4 | No | OK |
+| `48` | Angulated Multi-Unit | 54 | 54 | 20 | 0 | Yes | OK |
+| `50` | Scanbody adaptor | 121 | 104 | 98 | 16 | No | OK |
+| `52` | Dynamic scanbody | 77 | 56 | 37 | 20 | No | OK; blank section rows should not override prefix rule |
+| `53` | Scanbody / MU scanbody edge cases | 7 | 3 | 6 | 1 | Maybe | OK |
+| `54` | Scanbody OP / reference scanbody | 65 | 58 | 61 | 8 | No | OK |
+| `61` | DAS MU4.0 straight Multi-Unit | 53 | 1 | 14 | 52 | Yes | Check: MU by name/compatibility nums, catalog section mostly blank |
+| `62` | Internal Multi-Unit | 21 | 21 | 10 | 0 | Yes | OK |
+
+## Main validation notes
+
+- The audit now ignores no-compatibility-number rows. In this snapshot that excludes `0000` rows, including the previously listed `49.*` accessory/tool bucket.
+- `31.*` is confirmed as TiBase in scoped data: 724 product rows with compatibility nums, 638 compatibility option rows, mostly `STANDARD DYNAMIC TIBASE` or `DYNAMIC 3TIBASE`.
+- `35.*` should probably be treated as TiBase for business logic and VAT: it has 66 rows with compatibility nums, but 0 compatibility option rows and 65 blank catalog/category rows.
+- Multi-Unit is not one prefix only. Current data indicates `42.*`, `48.*`, `61.*`, and `62.*`; there are also small MU spillovers in other prefixes from import/category data.
+- `61.*` is the biggest classification gap inside scoped data: names and compatibility nums look like DAS MU4.0 straight Multi-Unit, but 52 of 53 rows have blank catalog/category.
+- Screw prefixes are split as `40.*` straight screw/healing-cap-ish rows and `41.*` dynamic screw rows. Both have many blank rows.
+- `ProductGroup.prefix` should not be used as the single source of product type because import grouping can create broad wildcard groups such as `31`, `35`, `40`, `41`, `42`, `52`, etc.
+
+## Family prefixes worth checking
+
+| Family prefix | Rows | Current signal |
+|---|---:|---|
+| `31.312` | 139 | TiBase, mostly standard/dynamic 3TiBase |
+| `31.313` | 129 | TiBase, mostly standard/dynamic 3TiBase |
+| `31.322` | 141 | TiBase, mostly standard/dynamic 3TiBase |
+| `31.323` | 135 | TiBase, mostly standard/dynamic 3TiBase |
+| `35.312` | 10 | Straight TiBase, mostly blank catalog data |
+| `35.313` | 10 | Straight TiBase, blank catalog data |
+| `35.322` | 10 | Straight TiBase, blank catalog data |
+| `35.323` | 10 | Straight TiBase, blank catalog data |
+| `42.302` | 75 | Straight Multi-Unit |
+| `42.303` | 76 | Straight Multi-Unit |
+| `48.312` | 50 | Angulated Multi-Unit |
+| `61.302` | 24 | MU4.0 straight Multi-Unit by name, blank section |
+| `61.303` | 29 | MU4.0 straight Multi-Unit by name, mostly blank section |
+| `62.303` | 11 | Internal Multi-Unit |
+
+## Suggested rule draft
+
+| Business bucket | Prefix rule draft | Confidence | Notes |
+|---|---|---|---|
+| TiBase | `31.*`, `35.*` | Medium-high | `31.*` is strong; `35.*` needs parser/category cleanup. |
+| Multi-Unit | `42.*`, `48.*`, `61.*`, `62.*` | Medium | `42/48/62` are strong; `61.*` needs section cleanup. |
+| Screws | `40.*`, `41.*` | Medium | Need separate straight/dynamic screw mapping and healing cap exceptions. |
+| Scanbody | `30.*`, `52.*`, `53.*`, `54.*` | Medium | `53.*` is mixed and small. |
+| Analogs / ScAnalog | `22.*`, `23.*`, `34.*` | High | Mostly consistent. |
+| Accessories/tools | `11.*`, `33.*`, `43.*`, `50.*` | Medium | `49.*` is out of scope here because current rows are `0000`. |
+
+## Next checks
+
+1. Decide whether VAT 5% should be driven by scoped prefix bucket, catalog section, or explicit product flag.
+2. Add parser/manual overrides for `35.*` and `61.*` if we want storefront/business logic to classify them reliably.
+3. Investigate blank catalog/category rows only for scoped prefixes that affect business rules: `31`, `35`, `42`, `48`, `61`, `62`.
+4. Keep exact compatibility CSV mappings as the source of screw/options compatibility; do not derive screw options from prefix alone.

--- a/frontend/src/api/products.ts
+++ b/frontend/src/api/products.ts
@@ -3,6 +3,7 @@ import client from './client';
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const CATEGORY_COUNTS_CACHE_KEY = 'category_counts_v1';
 const COMPAT_COUNTS_CACHE_KEY = 'compat_counts_v1';
+const PRODUCT_TYPE_COUNTS_CACHE_KEY = 'product_type_counts_v1';
 
 export const PRODUCT_STATS_CACHE_INVALIDATED_EVENT = 'products:stats-cache-invalidated';
 
@@ -10,6 +11,7 @@ export function invalidateProductStatsClientCache(): void {
     try {
         localStorage.removeItem(CATEGORY_COUNTS_CACHE_KEY);
         localStorage.removeItem(COMPAT_COUNTS_CACHE_KEY);
+        localStorage.removeItem(PRODUCT_TYPE_COUNTS_CACHE_KEY);
     } catch {
         // ignore storage access issues
     }
@@ -141,6 +143,7 @@ export interface ProductListParams {
     search?: string;
     ordering?: string;
     group?: number;
+    product_type?: string;
     categories?: string[];
     limit?: number;
     offset?: number;
@@ -182,6 +185,7 @@ export const getProductCount = async (params?: ProductListParams): Promise<numbe
 
     if (params?.search) query.set('search', params.search);
     if (typeof params?.group === 'number') query.set('group', String(params.group));
+    if (params?.product_type) query.set('product_type', params.product_type);
     (params?.categories || []).forEach((category) => query.append('categories', category));
     if (params?.compatibility_section) query.set('compatibility_section', params.compatibility_section);
     if (params?.compatibility_code) query.set('compatibility_code', params.compatibility_code);
@@ -217,6 +221,14 @@ export const getCategoryCounts = async (): Promise<Record<string, number>> => {
     if (cached) return cached;
     const response = await client.get<{ counts: Record<string, number> }>('/products/category-counts/');
     writeLocalCache(CATEGORY_COUNTS_CACHE_KEY, response.data.counts);
+    return response.data.counts;
+};
+
+export const getProductTypeCounts = async (): Promise<Record<string, number>> => {
+    const cached = readLocalCache<Record<string, number>>(PRODUCT_TYPE_COUNTS_CACHE_KEY);
+    if (cached) return cached;
+    const response = await client.get<{ counts: Record<string, number> }>('/products/product-type-counts/');
+    writeLocalCache(PRODUCT_TYPE_COUNTS_CACHE_KEY, response.data.counts);
     return response.data.counts;
 };
 

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -183,7 +183,7 @@ export default function ProductsPage() {
         staleTime: Infinity,
     });
 
-    const { data: productTypeCounts = {} } = useQuery({
+    const { data: productTypeCounts = {}, isLoading: productTypeCountsLoading } = useQuery({
         queryKey: ['product-type-counts'],
         queryFn: getProductTypeCounts,
         staleTime: Infinity,
@@ -210,7 +210,7 @@ export default function ProductsPage() {
     });
     const hasProductTypeCounts = Object.keys(productTypeCounts).length > 0;
     const availableProductTypeFilters = PRODUCT_TYPE_FILTERS.filter((option) => {
-        if (!hasProductTypeCounts) return true;
+        if (productTypeCountsLoading || !hasProductTypeCounts) return false;
         return (productTypeCounts[option.value] || 0) > 0 || option.value === selectedProductType;
     });
     const selectedProductTypeOption = PRODUCT_TYPE_FILTERS.find((option) => option.value === selectedProductType);
@@ -645,67 +645,71 @@ export default function ProductsPage() {
                             </button>
                         )}
                     </div>
-                    <div className="w-px h-6 bg-slate-200 flex-shrink-0" />
-                    <Listbox
-                        value={selectedProductType}
-                        onChange={(value: ProductTypeFilterValue | '') => setSelectedProductType(value)}
-                    >
-                        {({ open }) => (
-                            <div className="relative">
-                                <Listbox.Button
-                                    className={`inline-flex items-center gap-1.5 h-9 px-3 rounded-xl border text-sm font-medium transition-all focus:outline-none ${selectedProductType ? 'bg-cyan-50 border-cyan-200 text-cyan-700' : 'bg-white border-slate-200 text-slate-500 hover:border-slate-300 hover:text-slate-700'}`}
-                                >
-                                    <span className="truncate max-w-[9rem]">
-                                        {selectedProductTypeOption?.label || 'Typ produktu'}
-                                    </span>
-                                    <ChevronDownIcon className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
-                                </Listbox.Button>
+                    {availableProductTypeFilters.length > 0 && (
+                        <>
+                            <div className="w-px h-6 bg-slate-200 flex-shrink-0" />
+                            <Listbox
+                                value={selectedProductType}
+                                onChange={(value: ProductTypeFilterValue | '') => setSelectedProductType(value)}
+                            >
+                                {({ open }) => (
+                                    <div className="relative">
+                                        <Listbox.Button
+                                            className={`inline-flex items-center gap-1.5 h-9 px-3 rounded-xl border text-sm font-medium transition-all focus:outline-none ${selectedProductType ? 'bg-cyan-50 border-cyan-200 text-cyan-700' : 'bg-white border-slate-200 text-slate-500 hover:border-slate-300 hover:text-slate-700'}`}
+                                        >
+                                            <span className="truncate max-w-[9rem]">
+                                                {selectedProductTypeOption?.label || 'Typ produktu'}
+                                            </span>
+                                            <ChevronDownIcon className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
+                                        </Listbox.Button>
 
-                                <Transition
-                                    as={Fragment}
-                                    enter="transition ease-out duration-120"
-                                    enterFrom="opacity-0 scale-95 translate-y-1"
-                                    enterTo="opacity-100 scale-100 translate-y-0"
-                                    leave="transition ease-in duration-90"
-                                    leaveFrom="opacity-100 scale-100 translate-y-0"
-                                    leaveTo="opacity-0 scale-95 translate-y-1"
-                                >
-                                    <Listbox.Options className="absolute left-0 top-full z-30 mt-2 w-[20rem] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-[0_20px_45px_rgba(15,23,42,0.12)] py-2 focus:outline-none">
-                                        <Listbox.Option value="" as={Fragment}>
-                                            {({ active, selected }) => (
-                                                <button
-                                                    type="button"
-                                                    className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${active || selected ? 'bg-cyan-50 text-cyan-700' : 'text-slate-600 hover:bg-slate-50'}`}
-                                                >
-                                                    <span className="font-medium">Všetky typy</span>
-                                                    {!selectedProductType && <span className="text-xs font-semibold text-cyan-600">Filter</span>}
-                                                </button>
-                                            )}
-                                        </Listbox.Option>
-                                        {availableProductTypeFilters.map((option) => (
-                                            <Listbox.Option key={option.value} value={option.value} as={Fragment}>
-                                                {({ active, selected }) => (
-                                                    <button
-                                                        type="button"
-                                                        className={`flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors ${active || selected ? 'bg-cyan-50 text-cyan-700' : 'text-slate-700 hover:bg-slate-50'}`}
-                                                    >
-                                                        <span className="font-medium">{option.label}</span>
-                                                        <div className="flex flex-shrink-0 items-center gap-1.5">
-                                                            <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${selected ? 'bg-cyan-100 text-cyan-700' : 'bg-slate-100 text-slate-500'}`}>
-                                                                {productTypeCounts[option.value] || 0}
-                                                            </span>
-                                                            <span className="text-[11px] font-medium text-slate-400">{option.prefixes}</span>
-                                                        </div>
-                                                    </button>
-                                                )}
-                                            </Listbox.Option>
-                                        ))}
-                                    </Listbox.Options>
-                                </Transition>
-                            </div>
-                        )}
-                    </Listbox>
-                    <div className="w-px h-6 bg-slate-200 flex-shrink-0" />
+                                        <Transition
+                                            as={Fragment}
+                                            enter="transition ease-out duration-120"
+                                            enterFrom="opacity-0 scale-95 translate-y-1"
+                                            enterTo="opacity-100 scale-100 translate-y-0"
+                                            leave="transition ease-in duration-90"
+                                            leaveFrom="opacity-100 scale-100 translate-y-0"
+                                            leaveTo="opacity-0 scale-95 translate-y-1"
+                                        >
+                                            <Listbox.Options className="absolute left-0 top-full z-30 mt-2 w-[20rem] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-[0_20px_45px_rgba(15,23,42,0.12)] py-2 focus:outline-none">
+                                                <Listbox.Option value="" as={Fragment}>
+                                                    {({ active, selected }) => (
+                                                        <button
+                                                            type="button"
+                                                            className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${active || selected ? 'bg-cyan-50 text-cyan-700' : 'text-slate-600 hover:bg-slate-50'}`}
+                                                        >
+                                                            <span className="font-medium">Všetky typy</span>
+                                                            {!selectedProductType && <span className="text-xs font-semibold text-cyan-600">Filter</span>}
+                                                        </button>
+                                                    )}
+                                                </Listbox.Option>
+                                                {availableProductTypeFilters.map((option) => (
+                                                    <Listbox.Option key={option.value} value={option.value} as={Fragment}>
+                                                        {({ active, selected }) => (
+                                                            <button
+                                                                type="button"
+                                                                className={`flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors ${active || selected ? 'bg-cyan-50 text-cyan-700' : 'text-slate-700 hover:bg-slate-50'}`}
+                                                            >
+                                                                <span className="font-medium">{option.label}</span>
+                                                                <div className="flex flex-shrink-0 items-center gap-1.5">
+                                                                    <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${selected ? 'bg-cyan-100 text-cyan-700' : 'bg-slate-100 text-slate-500'}`}>
+                                                                        {productTypeCounts[option.value] || 0}
+                                                                    </span>
+                                                                    <span className="text-[11px] font-medium text-slate-400">{option.prefixes}</span>
+                                                                </div>
+                                                            </button>
+                                                        )}
+                                                    </Listbox.Option>
+                                                ))}
+                                            </Listbox.Options>
+                                        </Transition>
+                                    </div>
+                                )}
+                            </Listbox>
+                            <div className="w-px h-6 bg-slate-200 flex-shrink-0" />
+                        </>
+                    )}
                     {/* Compatibility filter */}
                     {sortedCompatibilityOptions.length > 0 && (
                         <>
@@ -1292,45 +1296,47 @@ export default function ProductsPage() {
                         </div>
 
                         {/* Product type */}
-                        <div className="mb-6 pt-5 border-t border-slate-100">
-                            <h3 className="text-sm font-bold text-slate-800 uppercase tracking-widest mb-3">Typ produktu</h3>
-                            <div className="space-y-1.5">
-                                <button
-                                    onClick={() => setSelectedProductType('')}
-                                    className={`w-full text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${
-                                        !selectedProductType
-                                            ? 'text-white'
-                                            : 'bg-slate-50 text-slate-700'
-                                    }`}
-                                    style={!selectedProductType ? { background: 'linear-gradient(135deg, #06b6d4, #10b981)' } : {}}
-                                >
-                                    Všetky typy
-                                </button>
-                                {availableProductTypeFilters.map((option) => {
-                                    const isActive = selectedProductType === option.value;
-                                    return (
-                                        <button
-                                            key={option.value}
-                                            onClick={() => setSelectedProductType(isActive ? '' : option.value)}
-                                            className={`flex w-full items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition ${
-                                                isActive ? 'text-white' : 'bg-slate-50 text-slate-700'
-                                            }`}
-                                            style={isActive ? { background: 'linear-gradient(135deg, #06b6d4, #10b981)' } : {}}
-                                        >
-                                            <span>{option.label}</span>
-                                            <div className="flex items-center gap-1.5">
-                                                <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${isActive ? 'bg-white/20 text-white' : 'bg-white text-slate-500'}`}>
-                                                    {productTypeCounts[option.value] || 0}
-                                                </span>
-                                                <span className={`text-[11px] font-semibold ${isActive ? 'text-white/70' : 'text-slate-400'}`}>
-                                                    {option.prefixes}
-                                                </span>
-                                            </div>
-                                        </button>
-                                    );
-                                })}
+                        {availableProductTypeFilters.length > 0 && (
+                            <div className="mb-6 pt-5 border-t border-slate-100">
+                                <h3 className="text-sm font-bold text-slate-800 uppercase tracking-widest mb-3">Typ produktu</h3>
+                                <div className="space-y-1.5">
+                                    <button
+                                        onClick={() => setSelectedProductType('')}
+                                        className={`w-full text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${
+                                            !selectedProductType
+                                                ? 'text-white'
+                                                : 'bg-slate-50 text-slate-700'
+                                        }`}
+                                        style={!selectedProductType ? { background: 'linear-gradient(135deg, #06b6d4, #10b981)' } : {}}
+                                    >
+                                        Všetky typy
+                                    </button>
+                                    {availableProductTypeFilters.map((option) => {
+                                        const isActive = selectedProductType === option.value;
+                                        return (
+                                            <button
+                                                key={option.value}
+                                                onClick={() => setSelectedProductType(isActive ? '' : option.value)}
+                                                className={`flex w-full items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition ${
+                                                    isActive ? 'text-white' : 'bg-slate-50 text-slate-700'
+                                                }`}
+                                                style={isActive ? { background: 'linear-gradient(135deg, #06b6d4, #10b981)' } : {}}
+                                            >
+                                                <span>{option.label}</span>
+                                                <div className="flex items-center gap-1.5">
+                                                    <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${isActive ? 'bg-white/20 text-white' : 'bg-white text-slate-500'}`}>
+                                                        {productTypeCounts[option.value] || 0}
+                                                    </span>
+                                                    <span className={`text-[11px] font-semibold ${isActive ? 'text-white/70' : 'text-slate-400'}`}>
+                                                        {option.prefixes}
+                                                    </span>
+                                                </div>
+                                            </button>
+                                        );
+                                    })}
+                                </div>
                             </div>
-                        </div>
+                        )}
 
                         {/* Categories */}
                         <div className="mb-6 pt-5 border-t border-slate-100">

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useInfiniteQuery, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { Helmet } from 'react-helmet-async';
-import { PRODUCT_STATS_CACHE_INVALIDATED_EVENT, getCategoryCounts, getCompatibilityCounts, getCompatibilityOptions, getProductCategories, getProductCount, getProducts, type CompatibilityOption, type Product, type ProductListParams } from '../api/products';
+import { PRODUCT_STATS_CACHE_INVALIDATED_EVENT, getCategoryCounts, getCompatibilityCounts, getCompatibilityOptions, getProductCategories, getProductCount, getProductTypeCounts, getProducts, type CompatibilityOption, type Product, type ProductListParams } from '../api/products';
 import { MagnifyingGlassIcon, ArrowUpIcon, ChevronDownIcon, TagIcon } from '@heroicons/react/24/outline';
 import DropdownSelect from '../components/DropdownSelect';
 import { Listbox, Transition } from '@headlessui/react';
@@ -30,6 +30,19 @@ const getNetPrice = (product: Product): string | null => product.price;
 
 const PAGE_SIZE = 20;
 const SEO_SITE_URL = import.meta.env.VITE_SITE_URL || window.location.origin;
+
+const PRODUCT_TYPE_FILTERS = [
+    { value: 'tibase', label: 'TiBase', prefixes: '31, 35' },
+    { value: 'multi_unit', label: 'Multi-Unit', prefixes: '42, 48, 61, 62' },
+    { value: 'screws', label: 'Skrutky', prefixes: '40, 41' },
+    { value: 'scanbody', label: 'Scanbody', prefixes: '30, 52, 53, 54' },
+    { value: 'analogs', label: 'Analógy', prefixes: '22, 23, 34' },
+    { value: 'abutments', label: 'Abutmenty', prefixes: '21' },
+    { value: 'adapters', label: 'Adaptéry', prefixes: '50' },
+    { value: 'tools', label: 'Nástroje', prefixes: '11, 33, 43' },
+] as const;
+
+type ProductTypeFilterValue = typeof PRODUCT_TYPE_FILTERS[number]['value'];
 
 const getVariantWord = (count: number): string => {
     const lastTwoDigits = count % 100;
@@ -66,6 +79,7 @@ export default function ProductsPage() {
     const [debouncedSearch, setDebouncedSearch] = useState('');
     const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
     const [selectedCompatibility, setSelectedCompatibility] = useState<CompatibilityOption | null>(null);
+    const [selectedProductType, setSelectedProductType] = useState<ProductTypeFilterValue | ''>('');
     const [priceSortOrder, setPriceSortOrder] = useState<'asc' | 'desc' | 'none'>('none');
     const [maxPrice, setMaxPrice] = useState(500);
     const [inStockOnly, setInStockOnly] = useState(false);
@@ -91,6 +105,7 @@ export default function ProductsPage() {
         const params: ProductListParams = { limit: PAGE_SIZE, offset };
         if (debouncedSearch) params.search = debouncedSearch;
         if (selectedCategories.length > 0) params.categories = selectedCategories;
+        if (selectedProductType) params.product_type = selectedProductType;
         if (selectedCompatibility) {
             params.compatibility_section = selectedCompatibility.section;
             params.compatibility_code = selectedCompatibility.compatibility_code;
@@ -100,7 +115,7 @@ export default function ProductsPage() {
             params.ordering = priceSortOrder === 'asc' ? 'price' : '-price';
         }
         return params;
-    }, [debouncedSearch, selectedCategories, selectedCompatibility, maxPrice, priceSortOrder]);
+    }, [debouncedSearch, selectedCategories, selectedProductType, selectedCompatibility, maxPrice, priceSortOrder]);
 
     const {
         data,
@@ -111,7 +126,7 @@ export default function ProductsPage() {
         isLoading,
         error,
     } = useInfiniteQuery({
-        queryKey: ['products', debouncedSearch, selectedCategories, selectedCompatibility, maxPrice, priceSortOrder],
+        queryKey: ['products', debouncedSearch, selectedCategories, selectedProductType, selectedCompatibility, maxPrice, priceSortOrder],
         queryFn: ({ pageParam = 0 }) => getProducts(buildParams(pageParam)),
         getNextPageParam: (lastPage) => {
             if (lastPage.next) {
@@ -126,10 +141,11 @@ export default function ProductsPage() {
     });
 
     const { data: databaseProductCount } = useQuery({
-        queryKey: ['products-count', debouncedSearch, selectedCategories, selectedCompatibility, maxPrice],
+        queryKey: ['products-count', debouncedSearch, selectedCategories, selectedProductType, selectedCompatibility, maxPrice],
         queryFn: () => getProductCount({
             search: debouncedSearch,
             categories: selectedCategories,
+            product_type: selectedProductType || undefined,
             compatibility_section: selectedCompatibility?.section,
             compatibility_code: selectedCompatibility?.compatibility_code,
             ...(maxPrice < 500 ? { max_price: maxPrice } : {}),
@@ -167,6 +183,12 @@ export default function ProductsPage() {
         staleTime: Infinity,
     });
 
+    const { data: productTypeCounts = {} } = useQuery({
+        queryKey: ['product-type-counts'],
+        queryFn: getProductTypeCounts,
+        staleTime: Infinity,
+    });
+
     // Keep only one option per compatibility code for storefront filters.
     // API options can include duplicate codes across different sections.
     const uniqueCompatibilityOptions = useMemo(() => {
@@ -186,6 +208,12 @@ export default function ProductsPage() {
         if (!isNaN(numA) && !isNaN(numB)) return numA - numB;
         return a.compatibility_code.localeCompare(b.compatibility_code);
     });
+    const hasProductTypeCounts = Object.keys(productTypeCounts).length > 0;
+    const availableProductTypeFilters = PRODUCT_TYPE_FILTERS.filter((option) => {
+        if (!hasProductTypeCounts) return true;
+        return (productTypeCounts[option.value] || 0) > 0 || option.value === selectedProductType;
+    });
+    const selectedProductTypeOption = PRODUCT_TYPE_FILTERS.find((option) => option.value === selectedProductType);
 
     // Show a suggestion when the search query matches a compatibility code (computed inline)
     const compatSuggestion = (() => {
@@ -220,6 +248,7 @@ export default function ProductsPage() {
         const handleStatsInvalidated = () => {
             void queryClient.invalidateQueries({ queryKey: ['category-counts'] });
             void queryClient.invalidateQueries({ queryKey: ['compatibility-counts'] });
+            void queryClient.invalidateQueries({ queryKey: ['product-type-counts'] });
             void queryClient.invalidateQueries({ queryKey: ['products-categories'] });
             void queryClient.invalidateQueries({ queryKey: ['products-count'] });
         };
@@ -328,6 +357,7 @@ export default function ProductsPage() {
         : null;
     const canUseCategoryBadgeCount = selectedCategories.length > 0
         && !debouncedSearch
+        && !selectedProductType
         && !selectedCompatibility
         && maxPrice >= 500
         && !inStockOnly;
@@ -397,7 +427,40 @@ export default function ProductsPage() {
             {/* Left Sidebar - Categories & Filters (Desktop only) */}
             <aside className="hidden lg:block w-60 bg-white border-r border-slate-200 fixed left-0 top-16 bottom-0 overflow-y-auto">
                 <div className="px-3 py-4">
+                    {/* Product types */}
+                    {availableProductTypeFilters.length > 0 && (
+                        <div className="mb-5">
+                            <p className="text-[11px] font-bold text-slate-400 uppercase tracking-[0.1em] mb-2.5">Typ produktu</p>
+                            <div className="space-y-0.5">
+                                <button
+                                    onClick={() => { setSelectedProductType(''); scrollToFilters(); }}
+                                    className="w-full text-left px-3 py-2 rounded-[10px] text-sm transition-all flex justify-between items-center"
+                                    style={!selectedProductType ? { background: '#e0f7fa', border: '1px solid rgba(8,145,178,0.2)', color: '#0891b2', fontWeight: 600 } : { border: '1px solid transparent', color: '#475569', fontWeight: 400 }}
+                                >
+                                    <span>Všetky typy</span>
+                                    <span className="text-[11px] px-1.5 py-0.5 rounded-full" style={{ background: '#f8fafc', color: '#94a3b8' }}>{Object.values(productTypeCounts).reduce((sum, count) => sum + count, 0)}</span>
+                                </button>
+                                {availableProductTypeFilters.map((option) => {
+                                    const active = selectedProductType === option.value;
+                                    const count = productTypeCounts[option.value] || 0;
+                                    return (
+                                        <button
+                                            key={option.value}
+                                            onClick={() => { setSelectedProductType(active ? '' : option.value); scrollToFilters(); }}
+                                            className="w-full text-left px-3 py-2 rounded-[10px] text-sm transition-all flex justify-between items-center"
+                                            style={active ? { background: '#e0f7fa', border: '1px solid rgba(8,145,178,0.2)', color: '#0891b2', fontWeight: 600 } : { border: '1px solid transparent', color: '#475569', fontWeight: 400 }}
+                                        >
+                                            <span>{option.label}</span>
+                                            <span className="text-[11px] px-1.5 py-0.5 rounded-full" style={{ background: active ? 'rgba(8,145,178,0.12)' : '#f8fafc', color: active ? '#0891b2' : '#94a3b8' }}>{count}</span>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+
                     {/* Categories */}
+                    <div className="h-px bg-slate-100 mb-3" />
                     <button
                         onClick={() => setCategoriesOpen(o => !o)}
                         className="w-full flex items-center justify-between mb-2.5 group"
@@ -583,6 +646,66 @@ export default function ProductsPage() {
                         )}
                     </div>
                     <div className="w-px h-6 bg-slate-200 flex-shrink-0" />
+                    <Listbox
+                        value={selectedProductType}
+                        onChange={(value: ProductTypeFilterValue | '') => setSelectedProductType(value)}
+                    >
+                        {({ open }) => (
+                            <div className="relative">
+                                <Listbox.Button
+                                    className={`inline-flex items-center gap-1.5 h-9 px-3 rounded-xl border text-sm font-medium transition-all focus:outline-none ${selectedProductType ? 'bg-cyan-50 border-cyan-200 text-cyan-700' : 'bg-white border-slate-200 text-slate-500 hover:border-slate-300 hover:text-slate-700'}`}
+                                >
+                                    <span className="truncate max-w-[9rem]">
+                                        {selectedProductTypeOption?.label || 'Typ produktu'}
+                                    </span>
+                                    <ChevronDownIcon className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`} />
+                                </Listbox.Button>
+
+                                <Transition
+                                    as={Fragment}
+                                    enter="transition ease-out duration-120"
+                                    enterFrom="opacity-0 scale-95 translate-y-1"
+                                    enterTo="opacity-100 scale-100 translate-y-0"
+                                    leave="transition ease-in duration-90"
+                                    leaveFrom="opacity-100 scale-100 translate-y-0"
+                                    leaveTo="opacity-0 scale-95 translate-y-1"
+                                >
+                                    <Listbox.Options className="absolute left-0 top-full z-30 mt-2 w-[20rem] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-[0_20px_45px_rgba(15,23,42,0.12)] py-2 focus:outline-none">
+                                        <Listbox.Option value="" as={Fragment}>
+                                            {({ active, selected }) => (
+                                                <button
+                                                    type="button"
+                                                    className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm transition-colors ${active || selected ? 'bg-cyan-50 text-cyan-700' : 'text-slate-600 hover:bg-slate-50'}`}
+                                                >
+                                                    <span className="font-medium">Všetky typy</span>
+                                                    {!selectedProductType && <span className="text-xs font-semibold text-cyan-600">Filter</span>}
+                                                </button>
+                                            )}
+                                        </Listbox.Option>
+                                        {availableProductTypeFilters.map((option) => (
+                                            <Listbox.Option key={option.value} value={option.value} as={Fragment}>
+                                                {({ active, selected }) => (
+                                                    <button
+                                                        type="button"
+                                                        className={`flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors ${active || selected ? 'bg-cyan-50 text-cyan-700' : 'text-slate-700 hover:bg-slate-50'}`}
+                                                    >
+                                                        <span className="font-medium">{option.label}</span>
+                                                        <div className="flex flex-shrink-0 items-center gap-1.5">
+                                                            <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${selected ? 'bg-cyan-100 text-cyan-700' : 'bg-slate-100 text-slate-500'}`}>
+                                                                {productTypeCounts[option.value] || 0}
+                                                            </span>
+                                                            <span className="text-[11px] font-medium text-slate-400">{option.prefixes}</span>
+                                                        </div>
+                                                    </button>
+                                                )}
+                                            </Listbox.Option>
+                                        ))}
+                                    </Listbox.Options>
+                                </Transition>
+                            </div>
+                        )}
+                    </Listbox>
+                    <div className="w-px h-6 bg-slate-200 flex-shrink-0" />
                     {/* Compatibility filter */}
                     {sortedCompatibilityOptions.length > 0 && (
                         <>
@@ -711,8 +834,15 @@ export default function ProductsPage() {
                 )}
 
                 {/* Desktop: active filter chips */}
-                {(selectedCategories.length > 0 || selectedCompatibility || inStockOnly || maxPrice < 500) && (
+                {(selectedCategories.length > 0 || selectedProductType || selectedCompatibility || inStockOnly || maxPrice < 500) && (
                     <div className="hidden lg:flex flex-wrap gap-2 mb-4">
+                        {selectedProductTypeOption && (
+                            <button onClick={() => setSelectedProductType('')}
+                                className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium cursor-pointer"
+                                style={{ background: '#e0f7fa', border: '1px solid rgba(8,145,178,0.25)', color: '#0891b2' }}>
+                                {selectedProductTypeOption.label} <span className="text-sm leading-none">×</span>
+                            </button>
+                        )}
                         {selectedCategories.map(c => (
                             <button key={c} onClick={() => setSelectedCategories(s => s.filter(x => x !== c))}
                                 className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium cursor-pointer transition-all"
@@ -773,18 +903,18 @@ export default function ProductsPage() {
                             onClick={() => setMobileFiltersOpen(true)}
                             className="relative flex items-center justify-center gap-1.5 h-10 px-3 rounded-xl flex-shrink-0 transition-all"
                             style={{
-                                background: (selectedCategories.length > 0 || maxPrice < 500 || inStockOnly || priceSortOrder !== 'none' || selectedCompatibility)
+                                background: (selectedCategories.length > 0 || selectedProductType || maxPrice < 500 || inStockOnly || priceSortOrder !== 'none' || selectedCompatibility)
                                     ? 'linear-gradient(135deg, #06b6d4, #10b981)'
                                     : 'rgba(255,255,255,0.07)',
                                 border: 'none',
                             }}
                         >
-                            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke={(selectedCategories.length > 0 || maxPrice < 500 || inStockOnly || priceSortOrder !== 'none' || selectedCompatibility) ? '#fff' : 'rgba(255,255,255,0.6)'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke={(selectedCategories.length > 0 || selectedProductType || maxPrice < 500 || inStockOnly || priceSortOrder !== 'none' || selectedCompatibility) ? '#fff' : 'rgba(255,255,255,0.6)'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                                 <line x1="4" y1="6" x2="20" y2="6"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="11" y1="18" x2="13" y2="18"/>
                             </svg>
-                            {(selectedCategories.length > 0 || maxPrice < 500 || inStockOnly || priceSortOrder !== 'none' || selectedCompatibility) && (
+                            {(selectedCategories.length > 0 || selectedProductType || maxPrice < 500 || inStockOnly || priceSortOrder !== 'none' || selectedCompatibility) && (
                                 <span className="text-xs font-bold text-white">
-                                    {selectedCategories.length + (selectedCompatibility ? 1 : 0) + (inStockOnly ? 1 : 0) + (maxPrice < 500 ? 1 : 0) + (priceSortOrder !== 'none' ? 1 : 0)}
+                                    {selectedCategories.length + (selectedProductType ? 1 : 0) + (selectedCompatibility ? 1 : 0) + (inStockOnly ? 1 : 0) + (maxPrice < 500 ? 1 : 0) + (priceSortOrder !== 'none' ? 1 : 0)}
                                 </span>
                             )}
                         </button>
@@ -819,7 +949,7 @@ export default function ProductsPage() {
 
                 <div className="mb-5 hidden lg:block">
                     <h1 className="text-2xl font-extrabold text-slate-900 tracking-tight leading-none">Naše produkty</h1>
-                    <p className="text-sm text-slate-400 mt-1">{visibleCount} produktov{selectedCategories.length > 0 ? ` v kategórii ${selectedCategories.join(', ')}` : ''}</p>
+                    <p className="text-sm text-slate-400 mt-1">{visibleCount} produktov{selectedProductTypeOption ? ` typu ${selectedProductTypeOption.label}` : selectedCategories.length > 0 ? ` v kategórii ${selectedCategories.join(', ')}` : ''}</p>
                 </div>
                 {/* Mobile heading */}
                 <div className="mb-3 mt-3 lg:hidden flex items-center justify-between">
@@ -1102,6 +1232,7 @@ export default function ProductsPage() {
                 searchQuery={debouncedSearch}
                 onCategoryClick={(category) => {
                     setSelectedCategories([category]);
+                    setSelectedProductType('');
                     scrollToFilters();
                 }}
                 onCompatibilityCodeClick={(code) => {
@@ -1113,6 +1244,7 @@ export default function ProductsPage() {
                 onReferenceClick={(reference) => {
                     setSelectedCompatibility(null);
                     setSelectedCategories([]);
+                    setSelectedProductType('');
                     setSearchQuery(reference);
                     scrollToFilters();
                 }}
@@ -1156,6 +1288,47 @@ export default function ProductsPage() {
                                         {label}
                                     </button>
                                 ))}
+                            </div>
+                        </div>
+
+                        {/* Product type */}
+                        <div className="mb-6 pt-5 border-t border-slate-100">
+                            <h3 className="text-sm font-bold text-slate-800 uppercase tracking-widest mb-3">Typ produktu</h3>
+                            <div className="space-y-1.5">
+                                <button
+                                    onClick={() => setSelectedProductType('')}
+                                    className={`w-full text-left px-3 py-2.5 rounded-lg text-sm font-medium transition ${
+                                        !selectedProductType
+                                            ? 'text-white'
+                                            : 'bg-slate-50 text-slate-700'
+                                    }`}
+                                    style={!selectedProductType ? { background: 'linear-gradient(135deg, #06b6d4, #10b981)' } : {}}
+                                >
+                                    Všetky typy
+                                </button>
+                                {availableProductTypeFilters.map((option) => {
+                                    const isActive = selectedProductType === option.value;
+                                    return (
+                                        <button
+                                            key={option.value}
+                                            onClick={() => setSelectedProductType(isActive ? '' : option.value)}
+                                            className={`flex w-full items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition ${
+                                                isActive ? 'text-white' : 'bg-slate-50 text-slate-700'
+                                            }`}
+                                            style={isActive ? { background: 'linear-gradient(135deg, #06b6d4, #10b981)' } : {}}
+                                        >
+                                            <span>{option.label}</span>
+                                            <div className="flex items-center gap-1.5">
+                                                <span className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${isActive ? 'bg-white/20 text-white' : 'bg-white text-slate-500'}`}>
+                                                    {productTypeCounts[option.value] || 0}
+                                                </span>
+                                                <span className={`text-[11px] font-semibold ${isActive ? 'text-white/70' : 'text-slate-400'}`}>
+                                                    {option.prefixes}
+                                                </span>
+                                            </div>
+                                        </button>
+                                    );
+                                })}
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- add audited product-type prefix groups for storefront filtering
- expose product type counts so empty groups are hidden in UI
- add product type controls to desktop top filters, left sidebar, and mobile filter sheet
- include internal prefix audit markdown and CSV

## Validation
- ./check-all.sh
- docker compose exec -T backend pytest products/tests.py -q
- docker compose exec -T backend black --check products/views.py products/tests.py products/urls.py products/cache_utils.py
- npm run lint -- src/pages/ProductsPage.tsx src/api/products.ts
- npm run build