### PR TITLE
Fix shop routing and admin refresh behavior

### DIFF
--- a/backend/products/compatibility.py
+++ b/backend/products/compatibility.py
@@ -157,6 +157,32 @@ def get_compatible_screws_for_tibase(reference, compatibility_code=None):
     }
 
 
+@lru_cache(maxsize=1)
+def _load_code_to_refs():
+    """Return {code: frozenset(refs)} for direct ref lookup by compatibility code."""
+    if not os.path.exists(_CSV_PATH):
+        return {}
+    raw = {}
+    with open(_CSV_PATH, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            code = row.get("compatibility_code", "").strip()
+            ref = row.get("reference", "").strip()
+            if code and ref:
+                raw.setdefault(code, set()).add(ref)
+    return {k: frozenset(v) for k, v in raw.items()}
+
+
+def get_all_compatible_refs(ref):
+    """Return all refs that share a compatibility code with *ref* (excluding *ref* itself)."""
+    codes = get_compatibility_codes_for_ref(ref)
+    code_to_refs = _load_code_to_refs()
+    result: set[str] = set()
+    for code in codes:
+        result.update(code_to_refs.get(code, frozenset()))
+    result.discard(ref)
+    return frozenset(result)
+
+
 def get_compatibility_counts():
     """Return {compatibility_code: product_count} dict. Cached with TTL."""
     csv_mtime = os.path.getmtime(_CSV_PATH) if os.path.exists(_CSV_PATH) else 0

--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -951,3 +951,39 @@ def test_catalog_page_search_falls_back_to_pypdf_without_pdftotext(monkeypatch):
     monkeypatch.setattr(views.subprocess, "run", fake_run)
 
     assert views._find_reference_pages("catalog.pdf", "50.312.120.03-2") == [1]
+
+
+def test_find_multiple_reference_pages_merges_refs(monkeypatch):
+    def fake_run(*_args, **_kwargs):
+        return types.SimpleNamespace(
+            returncode=0,
+            stdout="page one 40.316.003.01-2\fpage two 31.322.001.01-2\fpage three",
+        )
+
+    monkeypatch.setattr(views.subprocess, "run", fake_run)
+    refs = frozenset({"40.316.003.01-2", "31.322.001.01-2"})
+    assert views._find_multiple_reference_pages("catalog.pdf", refs) == [1, 2]
+
+
+def test_find_multiple_reference_pages_falls_back_to_pypdf(monkeypatch):
+    class Page:
+        def __init__(self, text):
+            self._text = text
+
+        def extract_text(self):
+            return self._text
+
+    class FakePdfReader:
+        def __init__(self, _path):
+            self.pages = [Page("contains 40.316.003.01-2"), Page("unrelated")]
+
+    fake_pypdf = types.SimpleNamespace(PdfReader=FakePdfReader)
+    monkeypatch.setitem(sys.modules, "pypdf", fake_pypdf)
+    monkeypatch.setattr(
+        views.subprocess,
+        "run",
+        lambda *_a, **_k: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+
+    refs = frozenset({"40.316.003.01-2", "99.999.999.01-2"})
+    assert views._find_multiple_reference_pages("catalog.pdf", refs) == [1]

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -1622,6 +1622,10 @@ class CatalogPdfPagesView(APIView):
 
     def get(self, request):
         reference = request.query_params.get("reference", "").strip()
+        include_compatible = request.query_params.get("include_compatible", "") in (
+            "1",
+            "true",
+        )
         if not reference:
             return Response({"pages": []})
 
@@ -1629,8 +1633,54 @@ class CatalogPdfPagesView(APIView):
         if not path:
             return Response({"pages": [], "error": "Catalog PDF not found"}, status=404)
 
-        matching = _find_reference_pages(path, reference)
+        if include_compatible:
+            from products.compatibility import get_all_compatible_refs  # noqa: PLC0415
+
+            all_refs = frozenset({reference}) | get_all_compatible_refs(reference)
+            matching = _find_multiple_reference_pages(path, all_refs)
+        else:
+            matching = _find_reference_pages(path, reference)
         return Response({"pages": matching})
+
+
+def _find_multiple_reference_pages(pdf_path: str, references: frozenset) -> list:
+    """Return sorted 1-based page numbers whose text contains any of the given references."""
+    try:
+        result = subprocess.run(
+            ["pdftotext", "-layout", pdf_path, "-"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=60,
+        )
+        if result.returncode == 0:
+            pages_text = result.stdout.split("\f")
+            return sorted(
+                i + 1
+                for i, page_text in enumerate(pages_text)
+                if any(
+                    _catalog_page_contains_reference(page_text, ref)
+                    for ref in references
+                )
+            )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    try:
+        from pypdf import PdfReader  # noqa: PLC0415
+
+        reader = PdfReader(pdf_path)
+        return sorted(
+            i + 1
+            for i, page in enumerate(reader.pages)
+            if any(
+                _catalog_page_contains_reference(page.extract_text() or "", ref)
+                for ref in references
+            )
+        )
+    except Exception:
+        return []
 
 
 def _find_reference_pages(pdf_path: str, reference: str) -> list:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -16,7 +16,7 @@ services:
       - dokploy-network
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.eplant-staging-backend.rule=(Host(`${STAGING_PRIMARY_DOMAIN:-dent.tomag.xyz}`) || Host(`${STAGING_SHOP_DOMAIN:-shop.dent.tomag.xyz}`)) && (PathPrefix(`/api`) || PathPrefix(`/admin`) || PathPrefix(`/media`))"
+      - "traefik.http.routers.eplant-staging-backend.rule=(Host(`${STAGING_PRIMARY_DOMAIN:-dent.tomag.xyz}`) || Host(`${STAGING_SHOP_DOMAIN:-shop.dent.tomag.xyz}`)) && (PathPrefix(`/api`) || PathPrefix(`/media`))"
       - "traefik.http.routers.eplant-staging-backend.entrypoints=web,websecure"
       - "traefik.http.routers.eplant-staging-backend.priority=10"
       - "traefik.http.routers.eplant-staging-backend.middlewares=eplant-security-headers@docker"
@@ -35,7 +35,7 @@ services:
     deploy:
       labels:
         - "traefik.enable=true"
-        - "traefik.http.routers.eplant-staging-backend.rule=(Host(`${STAGING_PRIMARY_DOMAIN:-dent.tomag.xyz}`) || Host(`${STAGING_SHOP_DOMAIN:-shop.dent.tomag.xyz}`)) && (PathPrefix(`/api`) || PathPrefix(`/admin`) || PathPrefix(`/media`))"
+        - "traefik.http.routers.eplant-staging-backend.rule=(Host(`${STAGING_PRIMARY_DOMAIN:-dent.tomag.xyz}`) || Host(`${STAGING_SHOP_DOMAIN:-shop.dent.tomag.xyz}`)) && (PathPrefix(`/api`) || PathPrefix(`/media`))"
         - "traefik.http.routers.eplant-staging-backend.entrypoints=web,websecure"
         - "traefik.http.routers.eplant-staging-backend.priority=10"
         - "traefik.http.routers.eplant-staging-backend.middlewares=eplant-security-headers@docker"

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -41,6 +41,10 @@ const createError = (overrides?: {
 };
 
 describe('API refresh interceptor', () => {
+    const setPathname = (pathname: string) => {
+        window.history.pushState({}, '', pathname);
+    };
+
     it('prevents refresh retry for refresh endpoint requests', () => {
         const refreshError = createError({ url: '/auth/refresh/' });
         expect(shouldAttemptTokenRefresh(refreshError)).toBe(false);
@@ -72,6 +76,7 @@ describe('API refresh interceptor', () => {
     });
 
     it('redirects to login when refresh fails', async () => {
+        setPathname('/orders');
         const apiClient = vi.fn();
         const refreshService: MockRefreshService = {
             refreshAccessToken: vi.fn().mockRejectedValue(new Error('expired refresh')),
@@ -86,6 +91,25 @@ describe('API refresh interceptor', () => {
             'expired refresh'
         );
         expect(refreshService.redirectToLogin).toHaveBeenCalledWith('/login');
+        expect(apiClient).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect public product visitors to login when refresh fails', async () => {
+        setPathname('/products');
+        const apiClient = vi.fn();
+        const refreshService: MockRefreshService = {
+            refreshAccessToken: vi.fn().mockRejectedValue(new Error('expired refresh')),
+            redirectToLogin: vi.fn(),
+        };
+        const handler = createAuthRefreshErrorHandler(
+            apiClient as never,
+            refreshService as never
+        );
+
+        await expect(handler(createError({ url: '/products/' }))).rejects.toThrow(
+            'expired refresh'
+        );
+        expect(refreshService.redirectToLogin).not.toHaveBeenCalled();
         expect(apiClient).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,6 +25,24 @@ type ErrorWithConfig = AxiosError & {
 type RefreshService = Pick<AuthService, 'refreshAccessToken' | 'redirectToLogin'>;
 
 const isAdminRequest = (requestUrl: string): boolean => requestUrl.includes('/admin/');
+const PUBLIC_ROUTES = [
+    '/',
+    '/products',
+    '/catalogs',
+    '/about',
+    '/login',
+    '/register',
+    '/verify-email',
+    '/forgot-password',
+    '/reset-password',
+    '/terms',
+    '/privacy',
+    '/complaints',
+    '/withdrawal',
+];
+
+const isPublicRoute = (pathname: string): boolean =>
+    PUBLIC_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`));
 
 export const shouldAttemptTokenRefresh = (error: ErrorWithConfig): boolean => {
     const originalRequest = error.config;
@@ -64,7 +82,9 @@ export const createAuthRefreshErrorHandler = (
         await refreshService.refreshAccessToken();
         return apiClient(originalRequest);
     } catch (refreshError) {
-        refreshService.redirectToLogin('/login');
+        if (!isPublicRoute(window.location.pathname)) {
+            refreshService.redirectToLogin('/login');
+        }
         return Promise.reject(refreshError);
     }
 };

--- a/frontend/src/components/CatalogPdfViewer.tsx
+++ b/frontend/src/components/CatalogPdfViewer.tsx
@@ -54,8 +54,10 @@ function waitForContainer(
     })
 }
 
-async function fetchMatchPages(reference: string): Promise<number[]> {
-    const url = `${CATALOG_PAGES_URL}?reference=${encodeURIComponent(reference)}`
+async function fetchMatchPages(reference: string, includeCompatible = false): Promise<number[]> {
+    const params = new URLSearchParams({ reference })
+    if (includeCompatible) params.set('include_compatible', '1')
+    const url = `${CATALOG_PAGES_URL}?${params.toString()}`
     catalogDebug('fetch match pages', { reference, url })
     const res = await fetch(url, {
         credentials: 'include',
@@ -233,7 +235,7 @@ export default function CatalogPdfViewer({ open, onClose, reference = '', pdfUrl
 
                 const [pdfDoc, apiPages] = await Promise.all([
                     pdfjsLib.getDocument({ url: activePdfUrl, withCredentials: true }).promise,
-                    fetchMatchPages(reference),
+                    fetchMatchPages(reference, true),
                 ])
 
                 if (cancelled) return

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -42,17 +42,6 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Admin Panel Proxy (Django admin) — stricter rate limit than API
-    location /admin/ {
-        limit_req zone=apizone burst=5 nodelay;
-
-        proxy_pass http://backend:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     # Django Static / Media files
     location /static/ {
         alias /usr/src/app/static/;
@@ -63,7 +52,6 @@ server {
     }
 
     # Valid SPA routes → index.html with 200
-    # /admin/* excluded — those are proxied to Django above
     location ~ ^/(products|about|cart|checkout|profile|orders|login|register|verify-email|forgot-password|reset-password|terms|privacy|complaints|withdrawal)(/.*)?$ {
         root /usr/share/nginx/html;
         try_files /index.html =500;
@@ -72,6 +60,7 @@ server {
     # Root and React admin dashboard root
     location = /       { root /usr/share/nginx/html; try_files /index.html =500; }
     location = /admin  { root /usr/share/nginx/html; try_files /index.html =500; }
+    location ^~ /admin/ { root /usr/share/nginx/html; try_files /index.html =500; }
 
     # Static assets (JS, CSS, images …) — serve if the file exists
     # Anything not matching a route above and not an existing file → 404


### PR DESCRIPTION
## Summary
- route `/admin/...` browser refreshes to the React app instead of Django
- remove stale Nginx `/admin/` backend proxy now that Django admin lives at `/django-admin/`
- stop staging Traefik from sending `/admin` paths to the backend; API/admin endpoints remain under `/api/...`
- keep public shop pages such as `/products` out of the global login redirect when token refresh fails

## Validation
- `docker compose -f docker-compose.staging.yml config`
- `docker run --rm --add-host backend:127.0.0.1 -v /home/tomas-magula/Documents/Projects/e-plant/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t`
- `npm test -- --run src/api/client.test.ts`
- `./check-all.sh`